### PR TITLE
Fix/mcc

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -347,9 +347,10 @@ impl<WA: ZKWASMArgs> ZKWASMContext<WasiCtx> for WASMCtx<WA> {
       end
     };
 
+    let start_opcode = self.args().trace_slice_values().start();
+
     // Slice etable if necessary
-    let etable =
-      ETable::new(etable.entries()[self.args().trace_slice_values().start()..end_opcode].to_vec());
+    let etable = ETable::new(etable.entries()[start_opcode..end_opcode].to_vec());
     tracing::trace!("Execution trace: {:#?}", etable);
 
     // Execution trace

--- a/src/run/batched/mod.rs
+++ b/src/run/batched/mod.rs
@@ -62,7 +62,7 @@ where
   S1: RelaxedR1CSSNARKTrait<E1>,
   S2: RelaxedR1CSSNARKTrait<Dual<E1>>,
 {
-  fn etable(&self) -> &ETable {
+  pub(crate) fn etable(&self) -> &ETable {
     &self.etable
   }
 }

--- a/src/run/tests.rs
+++ b/src/run/tests.rs
@@ -46,6 +46,9 @@ fn mock_mcc(tracer: Rc<RefCell<Tracer>>) -> anyhow::Result<()> {
     if m_entry.ltype != LocationType::Stack {
       continue;
     }
+    if m_entry.addr == 147504 {
+      tracing::debug!("addr: {:#?}", m_entry);
+    }
     match m_entry.atype {
       AccessType::Init => {
         mcc_map.insert(m_entry.addr, m_entry.value);

--- a/src/run/tests.rs
+++ b/src/run/tests.rs
@@ -1,23 +1,25 @@
-use std::{cell::RefCell, collections::HashMap, path::PathBuf, rc::Rc};
+use std::{ path::PathBuf};
 
-use super::batched::{BatchedZKEProof, BatchedZKEProofBuilder};
+use super::batched::{BatchedZKEProof, };
 use crate::{
   args::{WASMArgsBuilder, WASMCtx},
+
   traits::{
-    args::ZKWASMContext,
-    zkvm::{ZKVMBuilder, ZKVM},
+
+    zkvm::{ ZKVM},
   },
-  utils::{logging::init_logger, memory::set_linear_addr},
+  utils::{logging::init_logger, },
 };
-use anyhow::anyhow;
+
 use nova::{
   provider::{ipa_pc, PallasEngine},
   spartan::{self, snark::RelaxedR1CSSNARK},
   traits::Dual,
 };
 use wasmi::{
-  mtable::{AccessType, LocationType, MTable},
-  TraceSliceValues, Tracer,
+
+
+  TraceSliceValues,,
 };
 
 // Curve cycle to use for proving
@@ -31,51 +33,6 @@ type EE2<E> = ipa_pc::EvaluationEngine<Dual<E>>;
 type BS1<E> = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE1<E>>;
 type S1<E> = RelaxedR1CSSNARK<E, EE1<E>>;
 type S2<E> = RelaxedR1CSSNARK<Dual<E>, EE2<E>>;
-
-fn mock_mcc(tracer: Rc<RefCell<Tracer>>) -> anyhow::Result<()> {
-  let tracer = tracer.borrow();
-  let mtable = tracer.mtable();
-
-  let mut hash_map = HashMap::new();
-  let mut m_entries = mtable.entries().clone();
-
-  let mut mcc_map = HashMap::new();
-
-  for m_entry in m_entries.iter_mut() {
-    set_linear_addr(m_entry, &mut hash_map);
-    if m_entry.ltype != LocationType::Stack {
-      continue;
-    }
-    if m_entry.addr == 147504 {
-      tracing::debug!("addr: {:#?}", m_entry);
-    }
-    match m_entry.atype {
-      AccessType::Init => {
-        mcc_map.insert(m_entry.addr, m_entry.value);
-      }
-      AccessType::Write => {
-        mcc_map.insert(m_entry.addr, m_entry.value);
-      }
-      AccessType::Read => {
-        if !mcc_map.contains_key(&m_entry.addr)
-          || m_entry.value != *mcc_map.get(&m_entry.addr).unwrap()
-        {
-          println!("{:#?}", m_entry);
-          println!("addr: {}", m_entry.addr);
-          let value = mcc_map.get(&m_entry.addr);
-          println!("expected: {}, got: {:?}", m_entry.value, value);
-          println!("________________________________");
-          let etable = tracer.etable();
-          let entry = &etable.entries().to_vec()[m_entry.eid as usize - 1];
-
-          println!("{:#?}", entry);
-          return Err(anyhow!("Memory consistency check failed"));
-        }
-      }
-    }
-  }
-  Ok(())
-}
 
 #[test]
 fn test_gradient_boosting() -> anyhow::Result<()> {
@@ -104,51 +61,6 @@ fn test_gradient_boosting() -> anyhow::Result<()> {
   // Verify proof
   let result = proof.verify(public_values)?;
   Ok(assert!(result))
-}
-
-#[test]
-fn test_mock_mcc_gradient_boosting() -> anyhow::Result<()> {
-  init_logger();
-
-  // Configure the arguments needed for WASM execution
-  //
-  // Here we are configuring the path to the WASM file
-  let args = WASMArgsBuilder::default()
-    .file_path(PathBuf::from("wasm/gradient_boosting.wasm"))
-    .invoke(Some(String::from("_start")))
-    .trace_slice_values(TraceSliceValues::new(0, 1_000_000))
-    .build();
-
-  // Create a WASM execution context for proving.
-  let mut wasm_ctx = WASMCtx::new_from_file(args)?;
-
-  let _ = BatchedZKEProofBuilder::<E1, BS1<E1>, S1<E1>, S2<E1>>::get_trace(&mut wasm_ctx)?;
-  let tracer = wasm_ctx.tracer()?;
-  mock_mcc(tracer.clone())?;
-
-  Ok(())
-}
-
-#[test]
-fn test_mock_mcc_local_set_op() -> anyhow::Result<()> {
-  init_logger();
-
-  // Configure the arguments needed for WASM execution
-  //
-  // Here we are configuring the path to the WASM file
-  let args = WASMArgsBuilder::default()
-    .file_path(PathBuf::from("wasm/variable/local_set_op.wat"))
-    .invoke(Some(String::from("call")))
-    .build();
-
-  // Create a WASM execution context for proving.
-  let mut wasm_ctx = WASMCtx::new_from_file(args)?;
-
-  let _ = BatchedZKEProofBuilder::<E1, BS1<E1>, S1<E1>, S2<E1>>::get_trace(&mut wasm_ctx)?;
-  let tracer = wasm_ctx.tracer()?;
-  mock_mcc(tracer.clone())?;
-
-  Ok(())
 }
 
 mod k3 {

--- a/third-party/wasmi/crates/wasmi/src/tracer/etable/pre.rs
+++ b/third-party/wasmi/crates/wasmi/src/tracer/etable/pre.rs
@@ -49,7 +49,10 @@ pub enum RunInstructionTracePre {
         pre_block_value1: Option<u64>,
         pre_block_value2: Option<u64>,
     },
-    GrowMemory(i32),
+    GrowMemory {
+        grow_size: u32,
+        pages: u32,
+    },
 
     I32BinOp {
         left: i32,
@@ -132,7 +135,7 @@ pub enum RunInstructionTracePre {
         sign: bool,
     },
     F64ConvertI64 {
-        value: i64,
+        value: u64,
         sign: bool,
     },
     I32ReinterpretF32 {
@@ -180,8 +183,8 @@ pub enum RunInstructionTracePre {
     },
 
     F64BinOp {
-        left: f64,
-        right: f64,
+        left: u64,
+        right: u64,
     },
     MemoryFill {
         offset: u64,

--- a/third-party/wasmi/crates/wasmi/src/tracer/etable/step_info.rs
+++ b/third-party/wasmi/crates/wasmi/src/tracer/etable/step_info.rs
@@ -16,6 +16,7 @@ pub enum StepInfo {
         condition: u64,
         offset: u64,
     },
+    BrAdjustIfNez,
     BrAdjust {
         offset: u64,
     },
@@ -82,6 +83,7 @@ pub enum StepInfo {
     MemoryGrow {
         grow_size: i32,
         result: i32,
+        current_pages: u32,
     },
 
     I32Const {
@@ -227,8 +229,8 @@ pub enum StepInfo {
     },
 
     F64ConvertI64 {
-        value: i64,
-        result: f64,
+        value: u64,
+        result: u64,
         sign: bool,
     },
 
@@ -264,7 +266,7 @@ pub enum StepInfo {
     },
 
     F64Const {
-        value: f64,
+        value: u64,
     },
     F32Comp {
         class: RelOp,
@@ -287,9 +289,9 @@ pub enum StepInfo {
 
     F64BinOp {
         class: BinOp,
-        left: f64,
-        right: f64,
-        value: f64,
+        left: u64,
+        right: u64,
+        value: u64,
     },
     MemoryFill {
         value: u64,

--- a/wasm/variable/local_set_op.wat
+++ b/wasm/variable/local_set_op.wat
@@ -1,10 +1,12 @@
   (module
       (func (export "call")
           (local i32 i64)
-          (i32.const 0)
+          (i32.const 10)
           (local.set 0)
-          (i64.const 0)
+          (i64.const 100)
           (local.set 1)
+          (local.get 0)
+          drop
           (local.get 1)
           drop
       )

--- a/wasm/variable/local_set_op.wat
+++ b/wasm/variable/local_set_op.wat
@@ -9,5 +9,7 @@
           drop
           (local.get 1)
           drop
+          (local.get 0)
+          drop
       )
   )


### PR DESCRIPTION
Couple bad opcodes that needed to be fixed: Float opcodes and `CallInternal` opcode.

To fix the float opcodes I just had to change the way their bits were represented. Note: not all Floats were updated just the ones needed to get `gradient_boosting.wasm` MCC to work.

And to fix the `CallInternal` opcode I just had to include the stack writes it does in the memory trace