### PR TITLE
Feature/spartan2 prover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 pp.json
+vk.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=wyatt_dev#990217231c8a875996ca81ed18a7e43cc53a55d8"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=wyatt_dev#5f29204e056d3bc40b47edf145580bc5f8ffd7fa"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=wyatt_dev#9dd45d2b51362cb2495babfa0028a56276c262f6"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=wyatt_dev#990217231c8a875996ca81ed18a7e43cc53a55d8"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/examples/spartan.rs
+++ b/examples/spartan.rs
@@ -25,7 +25,6 @@ fn main() -> anyhow::Result<()> {
   let proof = LiteProver::prove(&mut wasm_ctx, &pp, &pk)?;
 
   tracing::info!("running verifier");
-  let result = proof.verify(&vk)?;
-  assert!(result);
+  proof.verify(&vk)?;
   Ok(())
 }

--- a/examples/spartan.rs
+++ b/examples/spartan.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+use zk_engine::{
+  snark::non_uniform::LiteProver,
+  utils::logging::init_logger,
+  wasm::{args::WASMArgsBuilder, ctx::WASMCtx},
+};
+
+fn main() -> anyhow::Result<()> {
+  init_logger();
+  let x = "1000";
+
+  let args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))
+    .invoke(Some(String::from("fib")))
+    .func_args(vec![String::from(x)])
+    .build();
+
+  tracing::info!("running setup");
+  let (pk, vk, pp) = LiteProver::setup(&mut WASMCtx::new_from_file(&args)?)?;
+
+  let mut wasm_ctx = WASMCtx::new_from_file(&args)?;
+
+  tracing::info!("running prover");
+  let proof = LiteProver::prove(&mut wasm_ctx, &pp, &pk)?;
+
+  tracing::info!("running verifier");
+  let result = proof.verify(&vk)?;
+  assert!(result);
+  Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod circuits;
 pub mod errors;
 pub mod pcd;
 pub mod run;
-mod snark;
+pub mod snark;
 pub mod traits;
 pub mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod circuits;
 pub mod errors;
 pub mod pcd;
 pub mod run;
+mod snark;
 pub mod traits;
 pub mod utils;
 
@@ -24,7 +25,8 @@ pub use wasmi_wasi::WasiCtx;
 // re-export `nova`
 pub use nova;
 
-type E1 = PallasEngine;
+/// Curve cycle used for testing...
+pub type E1 = PallasEngine;
 type EE1 = ipa_pc::EvaluationEngine<E1>;
 type EE2 = ipa_pc::EvaluationEngine<Dual<E1>>;
 type BS1 = spartan::batched::BatchedRelaxedR1CSSNARK<E1, EE1>;

--- a/src/snark/mod.rs
+++ b/src/snark/mod.rs
@@ -1,0 +1,1 @@
+pub mod non_uniform;

--- a/src/snark/mod.rs
+++ b/src/snark/mod.rs
@@ -1,1 +1,4 @@
+//! This module contains the Spartan prover for non-uniform circuits produced from WASM-execution
+//! trace.
+
 pub mod non_uniform;

--- a/src/snark/non_uniform.rs
+++ b/src/snark/non_uniform.rs
@@ -84,9 +84,8 @@ impl LiteProver {
   }
 
   /// Verify the correct execution of the non-uniform circuits used in WASM proving
-  pub fn verify(&self, vk: &VK) -> anyhow::Result<bool> {
-    self.snark.verify(&vk.vk)?;
-    Ok(true)
+  pub fn verify(&self, vk: &VK) -> anyhow::Result<()> {
+    self.snark.verify(&vk.vk)
   }
 }
 
@@ -177,9 +176,9 @@ impl NonUniformSNARK {
   }
 
   /// verify the SNARK
-  pub fn verify(&self, vk: &VerifierKey<E>) -> anyhow::Result<bool> {
+  pub fn verify(&self, vk: &VerifierKey<E>) -> anyhow::Result<()> {
     self.inner_snark.verify(vk, &self.instance)?;
-    Ok(true)
+    Ok(())
   }
 }
 
@@ -230,8 +229,7 @@ mod tests {
     let proof = LiteProver::prove(&mut wasm_ctx, &pp, &pk)?;
 
     tracing::info!("running verifier");
-    let result = proof.verify(&vk)?;
-    assert!(result);
+    proof.verify(&vk)?;
     Ok(())
   }
 
@@ -260,8 +258,7 @@ mod tests {
     let vk: super::VK = serde_json::from_str(&vk_str)?;
 
     tracing::info!("running verifier");
-    let result = proof.verify(&vk)?;
-    assert!(result);
+    proof.verify(&vk)?;
     Ok(())
   }
 }

--- a/src/snark/non_uniform.rs
+++ b/src/snark/non_uniform.rs
@@ -1,0 +1,237 @@
+use std::{cell::OnceCell, sync::Arc};
+
+use crate::{
+  circuits::supernova::batched_rom::BatchedROM, traits::args::ZKWASMContext,
+  utils::nivc::batch_execution_trace,
+};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
+use ff::Field;
+use itertools::Itertools;
+use nova::{
+  bellpepper::{
+    r1cs::{NovaShape, NovaWitness},
+    shape_cs::ShapeCS,
+    solver::SatisfyingAssignment,
+  },
+  provider::{ipa_pc, pedersen::CommitmentKey, PallasEngine},
+  r1cs::{
+    commitment_key_size, CommitmentKeyHint, R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness,
+  },
+  spartan::{
+    self,
+    batched_ppsnark::{ProverKey, VerifierKey},
+  },
+  supernova::{NonUniformCircuit, StepCircuit},
+  traits::{commitment::CommitmentEngineTrait, snark::BatchedRelaxedR1CSSNARKTrait, Engine},
+};
+use serde::{Deserialize, Serialize};
+use wasmi_wasi::WasiCtx;
+
+type E = PallasEngine;
+type PCS = ipa_pc::EvaluationEngine<E>;
+type SNARK = spartan::batched_ppsnark::BatchedRelaxedR1CSSNARK<E, PCS>;
+
+#[derive(Serialize, Deserialize)]
+struct VK {
+  #[serde(skip)]
+  vk: OnceCell<VerifierKey<E, PCS>>,
+}
+
+type PublicValues = (
+  ProverKey<E, PCS>, // pk
+  VK,                // vk
+  PublicParams,      // pp
+);
+
+struct LiteProver {
+  snark: NonUniformSNARK,
+}
+
+impl LiteProver {
+  fn setup(ctx: &mut impl ZKWASMContext<WasiCtx>) -> anyhow::Result<PublicValues> {
+    // Get execution trace (execution table)
+    let (etable, _) = ctx.build_execution_trace()?;
+    let tracer = ctx.tracer()?;
+
+    // Batch execution trace in batched
+    let (execution_trace, rom) = batch_execution_trace(&etable)?;
+
+    // Build large step circuits
+    let batched_rom = BatchedROM::<E>::new(rom, execution_trace.to_vec());
+    NonUniformSNARK::setup(batched_rom)
+  }
+
+  fn prove(
+    ctx: &mut impl ZKWASMContext<WasiCtx>,
+    pp: &PublicParams,
+    pk: &ProverKey<E, PCS>,
+  ) -> anyhow::Result<NonUniformSNARK> {
+    // Get execution trace (execution table)
+    let (etable, _) = ctx.build_execution_trace()?;
+    let tracer = ctx.tracer()?;
+
+    // Batch execution trace in batched
+    let (execution_trace, rom) = batch_execution_trace(&etable)?;
+
+    // Build large step circuits
+    let batched_rom = BatchedROM::<E>::new(rom, execution_trace.to_vec());
+    NonUniformSNARK::prove(pk, pp, batched_rom)
+  }
+
+  fn verify(&self, vk: VerifierKey<E, PCS>) -> anyhow::Result<bool> {
+    self.snark.verify(vk)?;
+    Ok(true)
+  }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PublicParams {
+  ck: CommitmentKey<E>,
+  r1cs_shapes: Vec<R1CSShape<E>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NonUniformSNARK {
+  inner_snark: SNARK,
+  instance: Vec<RelaxedR1CSInstance<E>>,
+}
+
+impl NonUniformSNARK {
+  fn setup(batched_rom: BatchedROM<E>) -> anyhow::Result<PublicValues> {
+    let circuit_shapes: Vec<R1CSShape<E>> = (0..batched_rom.num_circuits())
+      .map(|circuit_index| {
+        let mut cs: ShapeCS<E> = ShapeCS::new();
+        let one =
+          AllocatedNum::alloc_infallible(cs.namespace(|| "one"), || <E as Engine>::Scalar::ONE);
+        let _ = batched_rom
+          .primary_circuit(circuit_index)
+          .synthesize(
+            &mut cs,
+            Some(&one.clone()),
+            &vec![one.clone(); batched_rom.num_circuits()],
+          )
+          .expect("failed to synthesize");
+
+        cs.r1cs_shape()
+      })
+      .collect();
+
+    let ck = compute_ck_primary(&circuit_shapes, &*SNARK::ck_floor());
+
+    let (pk, vk) = SNARK::setup(Arc::new(ck.clone()), circuit_shapes.iter().collect())
+      .expect("failed to setup PP SNARK");
+
+    let pp = PublicParams {
+      ck,
+      r1cs_shapes: circuit_shapes,
+    };
+
+    let vk = VK {
+      vk: OnceCell::new(),
+    };
+    Ok((pk, vk, pp))
+  }
+
+  fn prove(
+    pk: &ProverKey<E, PCS>,
+    pp: &PublicParams,
+    batched_rom: BatchedROM<E>,
+  ) -> anyhow::Result<Self> {
+    // Get circuit instance's and witnesses
+    let mut U: Vec<RelaxedR1CSInstance<E>> = Vec::new();
+    let mut W: Vec<RelaxedR1CSWitness<E>> = Vec::new();
+    for (circuit_index, shape) in (0..batched_rom.num_circuits()).zip_eq(pp.r1cs_shapes.iter()) {
+      let mut cs = SatisfyingAssignment::<E>::new();
+
+      let one =
+        AllocatedNum::alloc_infallible(cs.namespace(|| "zero"), || <E as Engine>::Scalar::ONE);
+      let _ = batched_rom
+        .primary_circuit(circuit_index)
+        .synthesize(
+          &mut cs,
+          Some(&one.clone()),
+          &vec![one.clone(); batched_rom.num_circuits()],
+        )
+        .expect("failed to synthesize");
+
+      let (U_i, W_i) = cs
+        .r1cs_instance_and_witness(shape, &pp.ck)
+        .expect("failed to synthesize circuit");
+
+      U.push(RelaxedR1CSInstance::from_r1cs_instance(&pp.ck, shape, U_i));
+      W.push(RelaxedR1CSWitness::from_r1cs_witness(shape, W_i));
+    }
+
+    let S = pp.r1cs_shapes.iter().collect();
+    let proof = SNARK::prove(&pp.ck, pk, S, &U, &W)?;
+    Ok(Self {
+      inner_snark: proof,
+      instance: U,
+    })
+  }
+
+  // verify the SNARK
+  pub fn verify(&self, vk: VerifierKey<E, PCS>) -> anyhow::Result<bool> {
+    self.inner_snark.verify(&vk, &self.instance)?;
+    Ok(true)
+  }
+}
+
+/// Compute primary and secondary commitment keys sized to handle the largest of the circuits in the
+/// provided `R1CSWithArity`.
+fn compute_ck_primary(
+  circuit_shapes: &[R1CSShape<E>],
+  ck_hint1: &CommitmentKeyHint<E>,
+) -> CommitmentKey<E> {
+  let size_primary = circuit_shapes
+    .iter()
+    .map(|shape| commitment_key_size(&shape, ck_hint1))
+    .max()
+    .unwrap();
+
+  <E as Engine>::CE::setup(b"ck", size_primary)
+}
+
+#[cfg(test)]
+mod tests {
+  use std::path::PathBuf;
+
+  use nova::spartan::batched_ppsnark::VerifierKey;
+
+  use crate::{
+    args::{WASMArgsBuilder, WASMCtx},
+    snark::non_uniform::{E, PCS},
+    utils::logging::init_logger,
+  };
+
+  use super::LiteProver;
+
+  #[test]
+  fn test_lite_prover() -> anyhow::Result<()> {
+    init_logger();
+    let x = "1";
+    let size = "10";
+
+    let args = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/misc/uni-poly-eval.wasm"))
+      .invoke(Some(String::from("eval")))
+      .func_args(vec![String::from(x), String::from(size)])
+      .build();
+
+    tracing::info!("running setup");
+    let (pk, vk, pp) = LiteProver::setup(&mut WASMCtx::new_from_file(&args)?)?;
+
+    let mut wasm_ctx = WASMCtx::new_from_file(&args)?;
+
+    tracing::info!("running prover");
+    let proof = LiteProver::prove(&mut wasm_ctx, &pp, &pk)?;
+
+    let vk_str = serde_json::to_string(&vk)?;
+    // let vk: VerifierKey<E, PCS> = serde_json::from_str(&vk_str)?;
+
+    tracing::info!("running verifier");
+    let result = proof.verify(vk)?;
+
+    Ok(())
+  }
+}

--- a/src/snark/non_uniform.rs
+++ b/src/snark/non_uniform.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::{
-  circuits::supernova::batched_rom::BatchedROM, traits::args::ZKWASMContext,
+  circuits::supernova::batched_rom::BatchedROM, traits::wasm::ZKWASMContext,
   utils::nivc::batch_execution_trace,
 };
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
@@ -27,7 +27,6 @@ use nova::{
   traits::{commitment::CommitmentEngineTrait, snark::BatchedRelaxedR1CSSNARKTrait, Engine},
 };
 use serde::{Deserialize, Serialize};
-use wasmi_wasi::WasiCtx;
 
 type E = PallasEngine;
 type PCS = ipa_pc::EvaluationEngine<E>;
@@ -51,7 +50,7 @@ pub struct LiteProver {
 
 impl LiteProver {
   /// Setup the non-uniform circuits
-  pub fn setup(ctx: &mut impl ZKWASMContext<WasiCtx>) -> anyhow::Result<PublicValues> {
+  pub fn setup(ctx: &mut impl ZKWASMContext) -> anyhow::Result<PublicValues> {
     // Get execution trace (execution table)
     let (etable, _) = ctx.build_execution_trace()?;
 
@@ -65,7 +64,7 @@ impl LiteProver {
 
   /// Prove the non-uniform circuits
   pub fn prove(
-    ctx: &mut impl ZKWASMContext<WasiCtx>,
+    ctx: &mut impl ZKWASMContext,
     pp: &PublicParams,
     pk: &ProverKey<E, PCS>,
   ) -> anyhow::Result<Self> {
@@ -202,8 +201,8 @@ mod tests {
   use std::path::PathBuf;
 
   use crate::{
-    args::{WASMArgsBuilder, WASMCtx},
     utils::logging::init_logger,
+    wasm::{args::WASMArgsBuilder, ctx::WASMCtx},
   };
 
   use super::LiteProver;

--- a/src/snark/non_uniform.rs
+++ b/src/snark/non_uniform.rs
@@ -230,7 +230,7 @@ mod tests {
     // let vk: VerifierKey<E, PCS> = serde_json::from_str(&vk_str)?;
 
     tracing::info!("running verifier");
-    let result = proof.verify(vk)?;
+    // let result = proof.verify(vk)?;
 
     Ok(())
   }

--- a/src/traits/args.rs
+++ b/src/traits/args.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use wasmi::{etable::ETable, Func, Store, TraceSliceValues, Tracer};
 
 /// The trait to define what you need to run a WASM module and to expose the WASM modules bytecode.
+///
 /// You should be able to get a WASM modules bytecode and the function to invoke and its
 /// corresponding arguments.
 pub trait ZKWASMArgs {


### PR DESCRIPTION
**Add `LiteProver`: A Spartan Prover for zkWASM**

**Benefits:**
- Potentially better performance on small devices.
- No need to pass around a large Public Parameters (PP) file; instead, use a smaller verifier key.

**How it works:** 
Batches all opcodes into 10 steps and processes them using Spartan's batched pre-processing SNARK.

Check `/examples/spartan.rs` for usage instructions.
