### PR TITLE
 Feature/Make aggregation more IVC-like

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=wyatt_dev#8f7bdb8f0483540ed545c2887cd6cc263eb8bcd1"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=wyatt_dev#eb29f75259d0096ef4ed817cc00a3f043e29362f"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/src/pcd/aggregation/mod.rs
+++ b/src/pcd/aggregation/mod.rs
@@ -23,7 +23,6 @@ use nova::{
 use crate::{
   provider::{AggregationEngine, E},
   run::batched::{PublicParams, WasmSNARK},
-  //   traits::{be_engine::BackendEngine, public_values::ZKVMPublicParams},
 };
 
 #[cfg(test)]
@@ -46,15 +45,17 @@ type CompressedOutput = (
 pub struct Aggregator;
 
 impl Aggregator {
-  /// Prepare input SNARK's for aggregation
+  /// Prepare input SNARK's into format amenable to aggregation
+  ///
+  /// This requires the PP for the "input"/"child" SNARKs (the SNARKs to be aggregated)
   pub fn prepare_snarks<'a>(
-    pp: &'a PublicParams<AggregationEngine>,
+    wasm_pp: &'a PublicParams<AggregationEngine>,
     snarks: &[WasmSNARK<AggregationEngine>],
   ) -> anyhow::Result<Vec<AggregatorSNARKData<'a, PallasEngine>>> {
     // Get verifiers key which will be passed in the verify circuit
     //
     // The verifier key for each proof to be aggregated is the same
-    let vk = pp.execution().vk().primary();
+    let vk = wasm_pp.execution().vk().primary();
 
     // Convert SNARKS into data-structure ammenable to aggregation.
     let mut snarks_data = Vec::with_capacity(snarks.len());

--- a/src/pcd/aggregation/tests.rs
+++ b/src/pcd/aggregation/tests.rs
@@ -84,6 +84,11 @@ fn test_aggregator() -> anyhow::Result<()> {
   let time = Instant::now();
   tracing::info!("Aggregating SNARKs");
   // Pass in the previous recursive SNARK here to continue aggregation
+  //
+  // * NOTE
+  //
+  // PP does not have to be re-generated and we pass in the previous recursive SNARK to continue
+  // aggregation
   let new_recursive_snark = Aggregator::prove(&pp, &more_inputs, Some(recursive_snark))?;
   tracing::info!("Aggregation took: {:?}", time.elapsed());
 

--- a/src/pcd/aggregation/tests.rs
+++ b/src/pcd/aggregation/tests.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Instant};
+
+use anyhow::anyhow;
 
 use crate::{
   provider::AggregationEngine,
@@ -33,36 +35,67 @@ fn test_aggregator() -> anyhow::Result<()> {
   // Get public parameters for the SNARKs to be aggregated
   //
   // The Orchestrator Node (ON)/Aggregating node needs to run this to obtain the public
-  // parameters for the intermediate SNARKs, which will then be used as inputs to the verify circuit
+  // parameters for the intermediate SNARKs, which will then be used as inputs to the verify
+  // circuit
   let wasm_pp = WasmSNARK::<E>::setup(&mut WasiWASMCtx::new_from_file(&args)?)?;
 
-  // Get the public params, prover key, verifier key and data needed for aggregation
-  tracing::info!("setting up aggregator");
-  let (agg_pp, agg_pk, agg_vk, snarks_data) = Aggregator::setup(&wasm_pp, &snarks)?;
+  // Prepare SNARKs into a format ammenable to aggregation
+  let snarks_data = Aggregator::prepare_snarks(&wasm_pp, &snarks)?;
 
-  // Start the aggregation process and produce the final SNARK
-  let snark = Aggregator::prove(&agg_pp, &agg_pk, &snarks_data)?;
+  // Create inputs for public params and recursive SNARK
+  let inputs = Aggregator::build_verify_circuits(&snarks_data)?;
 
-  Ok(snark.verify(&agg_vk)?)
-}
+  // Generate the public parameters for the aggregator
+  let time = Instant::now();
+  tracing::info!("producing aggregator pp");
+  let pp = {
+    let (circuit_iop, circuit_ffa) = inputs.first().ok_or(anyhow!("No circuits"))?;
+    Aggregator::public_params(circuit_iop, circuit_ffa)?
+  };
+  tracing::info!("Time to create pp: {:?}", time.elapsed());
 
-#[test]
-#[ignore]
-fn test_aggregator_single() -> anyhow::Result<()> {
-  init_logger();
+  // This is where aggregation happens
+  let time = Instant::now();
+  tracing::info!("Aggregating SNARKs");
+  // Pass in None as the previous recursive SNARK since this is the first round of aggregation
+  let recursive_snark = Aggregator::prove(&pp, &inputs, None)?;
+  tracing::info!("Aggregation took: {:?}", time.elapsed());
 
-  let num_snarks = 1;
-  let args = WASMArgsBuilder::default()
-    .file_path(PathBuf::from("wasm/example.wasm"))
-    .build();
-  let wasm_pp = WasmSNARK::<E>::setup(&mut WasiWASMCtx::new_from_file(&args)?)?;
+  // Compress the recursive SNARK into a SNARK that will be used for verification
+  //
+  // This is the SNARK that will be sent to the client if they want an intermediate SNARK for the
+  // aggregation
+  let time = Instant::now();
+  tracing::info!("Compressing the final SNARK");
+  let (intermediate_final_snark, intermediate_vk) = Aggregator::compress(&pp, &recursive_snark)?;
+  tracing::info!("time to compress: {:?}", time.elapsed());
 
-  let snarks = gen_snarks(num_snarks, &args)?;
-  tracing::info!("setting up aggregator");
-  let (pp, pk, vk, snarks_data) = Aggregator::setup(&wasm_pp, &snarks)?;
-  let snark = Aggregator::prove(&pp, &pk, &snarks_data)?;
+  intermediate_final_snark.verify(&intermediate_vk, recursive_snark.num_steps())?;
 
-  Ok(snark.verify(&vk)?)
+  /*
+   * ROUND 2
+   * More incoming SNARKs to be aggregated
+   */
+  let more_snarks = gen_snarks(num_snarks, &args)?;
+
+  let more_snarks_data = Aggregator::prepare_snarks(&wasm_pp, &more_snarks)?;
+  let more_inputs = Aggregator::build_verify_circuits(&more_snarks_data)?;
+
+  let time = Instant::now();
+  tracing::info!("Aggregating SNARKs");
+  // Pass in the previous recursive SNARK here to continue aggregation
+  let new_recursive_snark = Aggregator::prove(&pp, &more_inputs, Some(recursive_snark))?;
+  tracing::info!("Aggregation took: {:?}", time.elapsed());
+
+  // You can compress here again to get the final SNARK that will be generated once all SNARKs have
+  // been aggregated
+  let time = Instant::now();
+  tracing::info!("Compressing the final SNARK");
+  let (final_snark, vk) = Aggregator::compress(&pp, &new_recursive_snark)?;
+  tracing::info!("time to compress: {:?}", time.elapsed());
+  final_snark.verify(&vk, new_recursive_snark.num_steps())?;
+
+  Ok(())
 }
 
 fn gen_snarks(num_snarks: usize, args: &WASMArgs) -> anyhow::Result<Vec<WasmSNARK<E>>> {


### PR DESCRIPTION
**Summary**: This PR introduces API changes to the `Aggregator` struct, making it more compatible with an IVC approach, allowing the aggregation process to remain open and continue down the line if needed

## Terminology:
1. **Child SNARKs**: The SNARKs to be aggregated.
2. **Parent SNARKs**: The `Aggregator` uses two parent SNARKs:
   - **RecursiveAggregatedSNARK** (rs or recursive SNARK for short): Performs the actual aggregation computation i.e runs verify circuit.
   - **CompressedAggregatedSNARK** (compressed SNARK): Represents the final SNARK at the end of aggregation or an intermediate SNARK if required by the client (e.g., during partial aggregation).

### New Methods in `Aggregator`:
- **`Aggregator::prepare_snarks`**: The first methd to call when aggregating child SNARKs. It converts child SNARKs into a format suitable for aggregation and takes the Public Parameters of the child SNARKs as input (distinct from the Aggregator's own PP generated later)
  
- **`Aggregator::build_verify_circuits`**: Takes the output from `prepare_snarks` and generates the necessary circuits used to produce the Aggregator’s Public Parameters.

- **`Aggregator::public_params`**: Generates the Aggregator's own Public Parameters from the previous step's output.

- **`Aggregator::prove`**: Generates a RecursiveAggregatedSNARK (rs). If starting a new aggregationn, pass `None` as the rs. If continuing a previous aggregation, use the existing rs. Note that when continuing aggregation, you don't need to recreate the Public Parameters—just reuse those from the previous aggregation.

- **`Aggregator::compress`**: Generates a compressed SNARK either when aggregation is complete or when the client requests an intermediate final SNARK (e.g., after 10 out of 20 SNARKs have been aggregated). This step is the most computationally expensive part of the aggregation.

To test:
`RUST_LOG=info cargo test --release --lib -- pcd::aggregation::tests::test_aggregator --ignored`

This test initially generates two child SNARKs, aggregates them, and produces an intermediate final compressed SNARK. It then generates two more child SNARKs, adds them to the existing aggregation, and finally produces the final compressed SNARK.
