### PR TITLE
Feat: Nebula 4.4.3 (Aggregation & Sharding)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula#126774a6b1833eef57dd3a61a04ec657f91eef97"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#d0163cbb96a1bc65d447640d8cc560765b053a44"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#bd7697737f0cc11cb2a683ae5453b4eee48a815b"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#cd2e7c20d7d23131a446e2312da906f3b9d10c49"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#cd2e7c20d7d23131a446e2312da906f3b9d10c49"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula#cd2e7c20d7d23131a446e2312da906f3b9d10c49"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#140d0b85f2e6e73eab8b9e9335883cae030541f7"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#bd7697737f0cc11cb2a683ae5453b4eee48a815b"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#d0163cbb96a1bc65d447640d8cc560765b053a44"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula-4.4.3#140d0b85f2e6e73eab8b9e9335883cae030541f7"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",
@@ -926,6 +926,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1094,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1266,6 +1299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1474,12 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semolina"
@@ -1627,6 +1675,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1816,19 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-texray"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b7943a21ef76920e7250b59946b0068221c323bf1077baab36164477d63efc"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "term_size",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2420,6 +2491,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "tracing-texray",
  "wasmi",
  "wasmi_wasi",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 wasmi = { path = "./third-party/wasmi/crates/wasmi" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/nebula", package = "arecibo" }
+nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/nebula-4.4.3", package = "arecibo" }
 bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bellpepper-core = { version = "0.4.0", default-features = false }
 ff = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 wasmi = { path = "./third-party/wasmi/crates/wasmi" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/nebula-4.4.3", package = "arecibo" }
+nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/nebula", package = "arecibo" }
 bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bellpepper-core = { version = "0.4.0", default-features = false }
 ff = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,15 @@ wasmi_wasi = { path = "./third-party/wasmi/crates/wasi" }
 [patch.crates-io]
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }
+
+[[example]]
+name = "fib"
+path = "examples/v1/fib.rs"
+
+[[example]]
+name = "fib_large"
+path = "examples/v1/fib_large.rs"
+
+[[example]]
+name = "kth_factor"
+path = "examples/v1/kth_factor.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ paste = "1.0.14"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing = { version = "0.1.40", features = ["log"] }
 thiserror = "1.0.61"
-
+tracing-texray = "0.2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/examples/v1/fib.rs
+++ b/examples/v1/fib.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+use zk_engine::{
+  nova::provider::Bn256EngineIPA,
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    wasm_ctx::{WASMArgsBuilder, WASMCtx},
+    wasm_snark::{StepSize, WasmSNARK},
+  },
+};
+
+// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+fn main() -> Result<(), ZKWASMError> {
+  init_logger();
+
+  // Specify step size.
+  //
+  // Here we choose `10` as the step size because the wasm execution of fib(16) is 253 opcodes.
+  // meaning zkWASM will run for 26 steps (rounds up).
+  let step_size = StepSize::new(10);
+
+  // Produce setup material
+  let pp = WasmSNARK::<E>::setup(step_size);
+
+  // Specify arguments to the WASM and use it to build a `WASMCtx`
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))
+    .unwrap()
+    .invoke("fib")
+    .func_args(vec![String::from("16")])
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+
+  // Prove wasm execution of fib.wat::fib(16)
+  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+
+  // Verify the proof
+  snark.verify(&pp, &instance)?;
+
+  Ok(())
+}

--- a/examples/v1/fib_large.rs
+++ b/examples/v1/fib_large.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+use zk_engine::{
+  nova::provider::Bn256EngineIPA,
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    wasm_ctx::{WASMArgsBuilder, WASMCtx},
+    wasm_snark::{StepSize, WasmSNARK},
+  },
+};
+
+// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+fn main() -> Result<(), ZKWASMError> {
+  init_logger();
+
+  // Specify step size.
+  //
+  // Here we choose `1_000` as the step size because the wasm execution of fib(1000) is 16,981
+  // opcodes. meaning zkWASM will run for 17 steps (rounds up).
+  let step_size = StepSize::new(1_000);
+
+  // Produce setup material
+  let pp = WasmSNARK::<E>::setup(step_size);
+
+  // Specify arguments to the WASM and use it to build a `WASMCtx`
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))
+    .unwrap()
+    .invoke("fib")
+    .func_args(vec![String::from("1000")])
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+
+  // Prove wasm execution of fib.wat::fib(1000)
+  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+
+  // Verify the proof
+  snark.verify(&pp, &instance)?;
+
+  Ok(())
+}

--- a/examples/v1/kth_factor.rs
+++ b/examples/v1/kth_factor.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+use zk_engine::{
+  nova::provider::Bn256EngineIPA,
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    wasm_ctx::{WASMArgsBuilder, WASMCtx},
+    wasm_snark::{StepSize, WasmSNARK},
+  },
+};
+
+// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+fn main() -> Result<(), ZKWASMError> {
+  init_logger();
+
+  // Here we chose execution step size of 1000 since the WASM execution is 7601 opcodes.
+  //
+  // However the memory size is 147456 address spaces, so we set memory step size to 50_000.
+  // Resulting in 3 steps for MCC
+  let step_size = StepSize::new(1000).set_memory_step_size(50_000);
+
+  // Produce setup material
+  let pp = WasmSNARK::<E>::setup(step_size);
+
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/nebula/kth_factor.wat"))?
+    .func_args(vec!["250".to_string(), "15".to_string()])
+    .invoke("kth_factor")
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+
+  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+
+  // Verify the proof
+  snark.verify(&pp, &instance)?;
+
+  Ok(())
+}

--- a/src/v1/README.md
+++ b/src/v1/README.md
@@ -12,3 +12,218 @@ The zkEngine is the backend for the [NovaNet](https://novanet.xyz) incentive and
 [dependencies]
 zk-engine = { git = "https://github.com/ICME-Lab/zkEngine_dev", branch= "main" }
 ```
+
+### Example
+
+#### First steps: Producing setup material.
+
+To prove and verify WASM program executions a prover and verifier both given the specification of the virtual machine (e.g., the instruction set architecture and semantics), which they have preprocess to obtain setup material. 
+
+This is done in form of producing a type exported from zk-engine called `WASMPublicParams`.
+
+```rust
+  let pp = WasmSNARK::<E>::setup(step_size);
+```
+
+You will notice to produce the public parameters you need to provide a `step_size` which is the number of instructions the zkWASM will execute at each step of the proving process. For example if you have a program with 100 instructions/opcodes and you set the `step_size` to 10, the proving process will be divided into 10 steps, each proving 10 instructions.
+
+```rust
+  let step_size = StepSize::new(10);
+  let pp = WasmSNARK::<E>::setup(step_size);
+```
+
+Choosing a bigger `step_size` can improve the proving time but will increase the memory consumption and vice versa. Make sure to choose a `step_size` that fits your use case.
+
+#### Fibonacci example
+
+Get the 16th fibonacci number using the wasm program in `wasm/misc/fib.wat`. The wasm program is a simple recursive function that calculates the fibonacci number of the input number.
+
+```bash
+RUST_LOG=debug cargo +nightly run --release --example fib
+```
+
+```rust
+use std::path::PathBuf;
+use zk_engine::{
+  nova::provider::Bn256EngineIPA,
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    wasm_ctx::{WASMArgsBuilder, WASMCtx},
+    wasm_snark::{StepSize, WasmSNARK},
+  },
+};
+
+// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+fn main() -> Result<(), ZKWASMError> {
+  init_logger();
+
+  // Specify step size.
+  //
+  // Here we choose `10` as the step size because the wasm execution of fib(16) is 253 opcodes.
+  // meaning zkWASM will run for 26 steps.
+  let step_size = StepSize::new(10);
+
+  // Produce setup material
+  let pp = WasmSNARK::<E>::setup(step_size);
+
+  // Specify arguments to the WASM and use it to build a `WASMCtx`
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))
+    .unwrap()
+    .invoke("fib")
+    .func_args(vec![String::from("16")])
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+
+  // Prove wasm execution of fib.wat::fib(16)
+  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+
+  // Verify the proof
+  snark.verify(&pp, &instance)?;
+
+  Ok(())
+}
+```
+
+## Note
+
+One thing to note about setting up your WASM program is this step
+```rust
+  // Specify arguments to the WASM and use it to build a `WASMCtx`
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))
+    .unwrap()
+    .invoke("fib")
+    .func_args(vec![String::from("16")])
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+```
+
+This is where you specify the wasm program to run and the function to invoke. The `func_args` is a vector of strings that are the arguments to the function you are invoking. In this case we are invoking the `fib` function with the argument `16`.
+
+Also if your WASM program uses `WASI` you would use:
+```rust
+  let wasm_ctx = WasiWASMCtx::new(wasm_args);
+```
+
+## Further Note
+*Public Parameters and WasmSNARK have to take the same `step_size` as an argument.*
+
+#### Bigger steps for better performance
+
+if you were to run fib(1000), this would take a long time to prove because the wasm program has 16,981 opcodes. To improve the proving time you can increase the `step_size` to 1000.
+
+```bash
+RUST_LOG=debug cargo +nightly run --release --example fib_large
+```
+
+```rust
+use std::path::PathBuf;
+use zk_engine::{
+  nova::provider::Bn256EngineIPA,
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    wasm_ctx::{WASMArgsBuilder, WASMCtx},
+    wasm_snark::{StepSize, WasmSNARK},
+  },
+};
+
+// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+fn main() -> Result<(), ZKWASMError> {
+  init_logger();
+
+  // Specify step size.
+  //
+  // Here we choose `1_000` as the step size because the wasm execution of fib(1000) is 16,981
+  // opcodes. meaning zkWASM will run for 17 steps (rounds up).
+  let step_size = StepSize::new(1_000);
+
+  // Produce setup material
+  let pp = WasmSNARK::<E>::setup(step_size);
+
+  // Specify arguments to the WASM and use it to build a `WASMCtx`
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))
+    .unwrap()
+    .invoke("fib")
+    .func_args(vec![String::from("1000")])
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+
+  // Prove wasm execution of fib.wat::fib(1000)
+  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+
+  // Verify the proof
+  snark.verify(&pp, &instance)?;
+
+  Ok(())
+}
+```
+
+## A better setup for Memory consistency checks
+
+Very often your WASM execution only produces a few thousand opcodes but sometimes the WASM linear memory is over hundreds of thousands of addresses. In this case since the memory consistency checks are proportional to the step size of proving execution, and so your proving time will be dominated by the memory consistency checks. To improve the memory proving time you can increase set memory_step_size on the `StepSize` struct.
+
+like so
+
+```rust
+  let step_size = StepSize::new(1000).set_memory_step_size(50_000);
+```
+
+#### Example
+
+In this WASM example (where the WASM calculates the kth factor of a number) the WASM execution produces 7601 opcodes so we choose a step size of 1,000. However the memory size is 147,456 address spaces, so we set memory step size to 50_000.
+Meaning the MCC will run in 3 steps.
+
+```bash
+RUST_LOG=debug cargo +nightly run --release --example kth_factor
+```
+
+```rust
+use std::path::PathBuf;
+use zk_engine::{
+  nova::provider::Bn256EngineIPA,
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    wasm_ctx::{WASMArgsBuilder, WASMCtx},
+    wasm_snark::{StepSize, WasmSNARK},
+  },
+};
+
+// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+fn main() -> Result<(), ZKWASMError> {
+  init_logger();
+
+  // Here we chose execution step size of 1000 since the WASM execution is 7601 opcodes.
+  //
+  // However the memory size is 147456 address spaces, so we set memory step size to 50_000.
+  // Resulting in 3 steps for MCC
+  let step_size = StepSize::new(1000).set_memory_step_size(50_000);
+
+  // Produce setup material
+  let pp = WasmSNARK::<E>::setup(step_size);
+
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/nebula/kth_factor.wat"))?
+    .func_args(vec!["250".to_string(), "15".to_string()])
+    .invoke("kth_factor")
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+
+  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+
+  // Verify the proof
+  snark.verify(&pp, &instance)?;
+
+  Ok(())
+}
+```

--- a/src/v1/README.md
+++ b/src/v1/README.md
@@ -1,0 +1,14 @@
+The zkEngine is an (NIVC) zkWASM implementation based on the [Nebula](https://eprint.iacr.org/2024/1605) proving scheme.
+It aims to be memory efficient and highly portable for constrained enviroments. With these traits it can be used for
+local verifiable compute and privacy on a large array of devices.
+
+The zkEngine is the backend for the [NovaNet](https://novanet.xyz) incentive and prover network. 
+
+## Usage: as Rust dependency
+
+### Cargo
+
+```toml
+[dependencies]
+zk-engine = { git = "https://github.com/ICME-Lab/zkEngine_dev", branch= "main" }
+```

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -8,6 +8,7 @@ use nova::{
   nebula::l2::{AggregationPublicParams, AggregationRecursiveSNARK},
   traits::CurveCycleEquipped,
 };
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;
@@ -21,6 +22,7 @@ where
 }
 
 /// Aggregation SNARK used to aggregate [`WasmSNARK`]'s
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AggregationSNARK<E>
 where
   E: CurveCycleEquipped,

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -1,0 +1,59 @@
+//! This module implements aggregation logic for the zkWASM.
+use nova::{
+  nebula::l2::{AggregationPublicParams, AggregationRecursiveSNARK},
+  traits::CurveCycleEquipped,
+};
+
+use super::{
+  error::ZKWASMError,
+  wasm_snark::{WASMPublicParams, WasmSNARK},
+};
+
+/// Get aggregation public parameters
+pub fn gen_aggregation_pp<E>(wasm_pp: WASMPublicParams<E>) -> AggregationPublicParams<E>
+where
+  E: CurveCycleEquipped,
+{
+  AggregationPublicParams::setup(wasm_pp)
+}
+
+/// Aggregation SNARK used to aggregate [`WasmSNARK`]'s
+pub struct AggregationSNARK<E>
+where
+  E: CurveCycleEquipped,
+{
+  rs: AggregationRecursiveSNARK<E>,
+}
+
+impl<E> AggregationSNARK<E>
+where
+  E: CurveCycleEquipped,
+{
+  /// Create a new instance of [`AggregationSNARK`]
+  pub fn new(
+    pp: &AggregationPublicParams<E>,
+    wasm_snark: &WasmSNARK<E>,
+  ) -> Result<Self, ZKWASMError> {
+    let rs = AggregationRecursiveSNARK::new(pp, wasm_snark)?;
+    Ok(Self { rs })
+  }
+
+  /// Aggregate the [`WasmSNARK`]s
+  pub fn aggregate(
+    &mut self,
+    pp: &AggregationPublicParams<E>,
+    wasm_snarks: &[WasmSNARK<E>],
+  ) -> Result<(), ZKWASMError> {
+    for snark in wasm_snarks {
+      self.rs.prove_step(pp, snark)?;
+    }
+
+    Ok(())
+  }
+
+  /// Verify the [`AggregationSNARK`]
+  pub fn verify(&self, pp: &AggregationPublicParams<E>) -> Result<(), ZKWASMError> {
+    self.rs.verify(pp)?;
+    Ok(())
+  }
+}

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -1,13 +1,16 @@
 //! This module implements aggregation logic for the zkWASM.
+use super::{
+  error::ZKWASMError,
+  wasm_snark::{WASMPublicParams, WasmSNARK, ZKWASMInstance},
+};
+use itertools::Itertools;
 use nova::{
   nebula::l2::{AggregationPublicParams, AggregationRecursiveSNARK},
   traits::CurveCycleEquipped,
 };
 
-use super::{
-  error::ZKWASMError,
-  wasm_snark::{WASMPublicParams, WasmSNARK},
-};
+#[cfg(test)]
+mod tests;
 
 /// Get aggregation public parameters
 pub fn gen_aggregation_pp<E>(wasm_pp: WASMPublicParams<E>) -> AggregationPublicParams<E>
@@ -33,19 +36,25 @@ where
   pub fn new(
     pp: &AggregationPublicParams<E>,
     wasm_snark: &WasmSNARK<E>,
+    U: &ZKWASMInstance<E>,
   ) -> Result<Self, ZKWASMError> {
-    let rs = AggregationRecursiveSNARK::new(pp, wasm_snark)?;
+    let rs = AggregationRecursiveSNARK::new(pp, wasm_snark, U)?;
     Ok(Self { rs })
   }
 
   /// Aggregate the [`WasmSNARK`]s
+  ///
+  /// # Panics
+  ///
+  /// Panics if the number of [`WasmSNARK`]'s and U's ([`ZKWASMInstance`]'s) are not equal
   pub fn aggregate(
     &mut self,
     pp: &AggregationPublicParams<E>,
     wasm_snarks: &[WasmSNARK<E>],
+    U: &[ZKWASMInstance<E>],
   ) -> Result<(), ZKWASMError> {
-    for snark in wasm_snarks {
-      self.rs.prove_step(pp, snark)?;
+    for (snark, U) in wasm_snarks.iter().zip_eq(U.iter()) {
+      self.rs.prove_step(pp, snark, U)?;
     }
 
     Ok(())

--- a/src/v1/aggregation/tests.rs
+++ b/src/v1/aggregation/tests.rs
@@ -1,0 +1,147 @@
+use crate::{
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    utils::macros::{start_timer, stop_timer},
+    wasm_ctx::{WASMArgsBuilder, WASMCtx, WasiWASMCtx, ZKWASMCtx},
+    wasm_snark::{StepSize, WASMPublicParams, WasmSNARK, ZKWASMInstance},
+  },
+};
+use nova::provider::Bn256EngineIPA;
+use std::{path::PathBuf, time::Instant};
+
+use super::{gen_aggregation_pp, AggregationSNARK};
+
+/// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+#[test]
+fn test_aggregation_bit_check() -> Result<(), ZKWASMError> {
+  let step_size = StepSize::new(16);
+  init_logger();
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/nebula/bit_check.wat"))
+    .unwrap()
+    .invoke("bit_check")
+    .func_args(vec!["255".to_string(), "255".to_string()])
+    .build();
+
+  let wasm_program = WASMCtx::new(wasm_args);
+  let num_nodes = 10;
+
+  sim_nodes_and_orchestrator_node(&wasm_program, step_size, num_nodes);
+
+  Ok(())
+}
+
+#[test]
+fn test_aggregation_int_opcodes() -> Result<(), ZKWASMError> {
+  let step_size = StepSize::new(100);
+  init_logger();
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/int_opcodes.wat"))
+    .unwrap()
+    .build();
+
+  let wasm_program = WASMCtx::new(wasm_args);
+  let num_nodes = 10;
+
+  sim_nodes_and_orchestrator_node(&wasm_program, step_size, num_nodes);
+
+  Ok(())
+}
+
+#[test]
+fn test_aggregation_eq_func() -> Result<(), ZKWASMError> {
+  let step_size = StepSize::new(500);
+  init_logger();
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/nebula/eq_func.wat"))
+    .unwrap()
+    .invoke("eq_func")
+    .func_args(vec!["255".to_string(), "255".to_string()])
+    .build();
+
+  let wasm_program = WASMCtx::new(wasm_args);
+  let num_nodes = 10;
+
+  sim_nodes_and_orchestrator_node(&wasm_program, step_size, num_nodes);
+
+  Ok(())
+}
+
+#[test]
+fn test_aggregation_zk_ads() {
+  init_logger();
+  let step_size = StepSize::new(500).set_memory_step_size(50_000);
+  let input_x = "200.05";
+  let input_y = "-30.0";
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+    .unwrap()
+    .func_args(vec![
+      String::from("0"),
+      String::from(input_x),
+      String::from(input_y),
+    ])
+    .invoke("is_user_close_enough")
+    .build();
+
+  let wasm_program = WasiWASMCtx::new(wasm_args);
+  let num_nodes = 10;
+
+  sim_nodes_and_orchestrator_node(&wasm_program, step_size, num_nodes);
+}
+
+fn sim_nodes_and_orchestrator_node(
+  wasm_program: &impl ZKWASMCtx,
+  step_size: StepSize,
+  num_nodes: usize,
+) {
+  // Public parameters used by [`WasmSNARK`]
+  //
+  // All nodes will use the same public parameters
+  let node_pp = WasmSNARK::<E>::setup(step_size);
+
+  let (node_snarks, node_instances) = node_nw(&node_pp, wasm_program, num_nodes, step_size);
+
+  /*
+   * ********** Aggregation (Orchestrator Node work) **********
+   */
+
+  let aggregation_pp = gen_aggregation_pp(node_pp);
+
+  // This SNARK will testify that all node SNARKs are correct
+  let mut aggregation_snark =
+    AggregationSNARK::new(&aggregation_pp, &node_snarks[0], &node_instances[0]).unwrap();
+
+  let aggregation_proof_timer = start_timer!("Proving Aggregation");
+  aggregation_snark
+    .aggregate(&aggregation_pp, &node_snarks, &node_instances)
+    .unwrap();
+
+  stop_timer!(aggregation_proof_timer);
+}
+
+fn node_nw(
+  node_pp: &WASMPublicParams<E>,
+  wasm_program: &impl ZKWASMCtx,
+  num_nodes: usize,
+  step_size: StepSize,
+) -> (Vec<WasmSNARK<E>>, Vec<ZKWASMInstance<E>>) {
+  let mut node_snarks = Vec::new();
+  let mut node_instances = Vec::new();
+
+  for i in 0..num_nodes {
+    let node_timer = start_timer!(format!("Node Proving {}/{}", i + 1, num_nodes));
+
+    let (snark, U) = WasmSNARK::<E>::prove(node_pp, wasm_program, step_size).unwrap();
+    snark.verify(node_pp, &U).unwrap();
+
+    node_snarks.push(snark);
+    node_instances.push(U);
+    stop_timer!(node_timer);
+  }
+
+  (node_snarks, node_instances)
+}

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -1,6 +1,8 @@
 //! V1 of zkEngine: Implements the Nebula paper for WASM ISA
 #![allow(clippy::type_complexity)]
+pub mod aggregation;
 pub mod error;
+pub mod sharding;
 #[cfg(test)]
 mod tests;
 mod utils;

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -1,0 +1,64 @@
+//! This module implements the sharding logic for the zkWASM.
+//!
+//! i.e. continuations
+
+use nova::{
+  nebula::l2::sharding::{ShardingPublicParams, ShardingRecursiveSNARK},
+  traits::CurveCycleEquipped,
+};
+
+use super::{
+  error::ZKWASMError,
+  wasm_snark::{WASMPublicParams, WasmSNARK, ZKWASMInstance},
+};
+
+/// Generate sharding public parameters
+pub fn gen_sharding_pp<E>(wasm_pp: WASMPublicParams<E>) -> ShardingPublicParams<E>
+where
+  E: CurveCycleEquipped,
+{
+  ShardingPublicParams::setup(wasm_pp)
+}
+
+/// Sharding SNARK used to aggregate [`WasmSNARK`]'s
+pub struct ShardingSNARK<E>
+where
+  E: CurveCycleEquipped,
+{
+  rs: ShardingRecursiveSNARK<E>,
+}
+
+impl<E> ShardingSNARK<E>
+where
+  E: CurveCycleEquipped,
+{
+  /// Create a new instance of [`ShardingSNARK`]
+  pub fn new(
+    pp: &ShardingPublicParams<E>,
+    wasm_snark: &WasmSNARK<E>,
+    U: &ZKWASMInstance<E>,
+  ) -> Result<Self, ZKWASMError> {
+    let rs = ShardingRecursiveSNARK::new(pp, wasm_snark, U)?;
+    Ok(Self { rs })
+  }
+
+  /// Combine the shards [`WasmSNARK`]s
+  pub fn sharding(
+    &mut self,
+    pp: &ShardingPublicParams<E>,
+    wasm_snarks: &[WasmSNARK<E>],
+    U: &ZKWASMInstance<E>,
+  ) -> Result<(), ZKWASMError> {
+    for snark in wasm_snarks {
+      self.rs.prove_step(pp, snark, U)?;
+    }
+
+    Ok(())
+  }
+
+  /// Verify the [`ShardingSNARK`]
+  pub fn verify(&self, pp: &ShardingPublicParams<E>) -> Result<(), ZKWASMError> {
+    self.rs.verify(pp)?;
+    Ok(())
+  }
+}

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -2,16 +2,14 @@
 //!
 //! i.e. continuations
 
-use nova::{
-  nebula::l2::sharding::{ShardingPublicParams, ShardingRecursiveSNARK},
-  traits::CurveCycleEquipped,
-};
-
 use super::{
   error::ZKWASMError,
   wasm_snark::{WASMPublicParams, WasmSNARK, ZKWASMInstance},
 };
-
+use nova::{
+  nebula::l2::sharding::{ShardingPublicParams, ShardingRecursiveSNARK},
+  traits::CurveCycleEquipped,
+};
 /// Generate sharding public parameters
 pub fn gen_sharding_pp<E>(wasm_pp: WASMPublicParams<E>) -> ShardingPublicParams<E>
 where
@@ -60,5 +58,104 @@ where
   pub fn verify(&self, pp: &ShardingPublicParams<E>) -> Result<(), ZKWASMError> {
     self.rs.verify(pp)?;
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::path::PathBuf;
+
+  use nova::{
+    nebula::l2::sharding::MemoryCommitmentsTraits, provider::Bn256EngineIPA, traits::Engine,
+  };
+  use tracing::info_span;
+
+  use super::{gen_sharding_pp, ShardingSNARK};
+  use crate::{
+    utils::logging::init_logger,
+    v1::{
+      utils::{
+        macros::{start_timer, stop_timer},
+        tracing::estimate_wasm,
+      },
+      wasm_ctx::{TraceSliceValues, WASMArgsBuilder, WasiWASMCtx},
+      wasm_snark::{StepSize, WasmSNARK, ZKWASMInstance},
+    },
+  };
+  use ff::Field;
+  use std::time::Instant;
+
+  /// Curve Cycle to prove/verify on
+  pub type E = Bn256EngineIPA;
+
+  #[test]
+  fn test_sharding_zk_ads() {
+    init_logger();
+    let step_size = StepSize::new(100).set_memory_step_size(50_000);
+    let input_x = "200.05";
+    let input_y = "-30.0";
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+      .unwrap()
+      .func_args(vec![
+        String::from("0"),
+        String::from(input_x),
+        String::from(input_y),
+      ])
+      .invoke("is_user_close_enough");
+
+    let pp = WasmSNARK::<E>::setup(step_size);
+
+    let shard_opcode_size = 500;
+    let mut start = 0;
+    let mut end = shard_opcode_size;
+
+    let mut node_snarks: Vec<(WasmSNARK<E>, ZKWASMInstance<E>)> = Vec::new();
+
+    let (trace, _, _, _) =
+      estimate_wasm(WasiWASMCtx::new(wasm_args_builder.clone().build())).unwrap();
+    let trace_len = trace.len();
+
+    let num_shards = {
+      let mut res = trace_len / shard_opcode_size;
+      if trace_len % shard_opcode_size != 0 {
+        res += 1;
+      }
+      res
+    };
+
+    for i in 0..num_shards {
+      let shard_proving_timer = start_timer!(format!("Proving Shard {i}"));
+      let wasm_ctx = WasiWASMCtx::new(
+        wasm_args_builder
+          .clone()
+          .trace_slice(TraceSliceValues::new(start, end))
+          .build(),
+      );
+
+      let (snark, U) = WasmSNARK::<E>::prove(&pp, wasm_ctx, step_size).unwrap();
+      snark.verify(&pp, &U).unwrap();
+      node_snarks.push((snark, U));
+      start = end;
+      end += shard_opcode_size;
+      stop_timer!(shard_proving_timer);
+    }
+
+    let sharding_pp_timer = start_timer!("Producing sharding PP");
+    let sharding_pp = gen_sharding_pp(pp);
+    stop_timer!(sharding_pp_timer);
+
+    let mut sharding_snark =
+      ShardingSNARK::new(&sharding_pp, &node_snarks[0].0, &node_snarks[0].1).unwrap();
+
+    for (i, (snark, U)) in node_snarks.iter().enumerate() {
+      let sharding_proof_timer = start_timer!(format!("Proving Sharding: shard {i}"));
+      sharding_snark
+        .prove_sharding(&sharding_pp, &[snark.clone()], U)
+        .unwrap();
+      stop_timer!(sharding_proof_timer);
+    }
+
+    sharding_snark.verify(&sharding_pp).unwrap();
   }
 }

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -63,12 +63,8 @@ where
 
 #[cfg(test)]
 mod tests {
+  use nova::provider::Bn256EngineIPA;
   use std::path::PathBuf;
-
-  use nova::{
-    nebula::l2::sharding::MemoryCommitmentsTraits, provider::Bn256EngineIPA, traits::Engine,
-  };
-  use tracing::info_span;
 
   use super::{gen_sharding_pp, ShardingSNARK};
   use crate::{
@@ -78,11 +74,10 @@ mod tests {
         macros::{start_timer, stop_timer},
         tracing::estimate_wasm,
       },
-      wasm_ctx::{TraceSliceValues, WASMArgsBuilder, WasiWASMCtx},
-      wasm_snark::{StepSize, WasmSNARK, ZKWASMInstance},
+      wasm_ctx::{TraceSliceValues, WASMArgsBuilder, WasiWASMCtx, ZKWASMCtx},
+      wasm_snark::{StepSize, WASMPublicParams, WasmSNARK, ZKWASMInstance},
     },
   };
-  use ff::Field;
   use std::time::Instant;
 
   /// Curve Cycle to prove/verify on
@@ -104,28 +99,147 @@ mod tests {
       ])
       .invoke("is_user_close_enough");
 
-    let pp = WasmSNARK::<E>::setup(step_size);
-
     let shard_opcode_size = 500;
-    let mut start = 0;
-    let mut end = shard_opcode_size;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
 
-    let mut node_snarks: Vec<(WasmSNARK<E>, ZKWASMInstance<E>)> = Vec::new();
+  #[test]
+  fn test_sharding_bulk_ops() {
+    init_logger();
+    let step_size = StepSize::new(200).set_memory_step_size(10_000);
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/misc/bulk-ops.wat"))
+      .unwrap()
+      .func_args(vec!["200".to_string()]);
 
-    let (trace, _, _, _) =
-      estimate_wasm(WasiWASMCtx::new(wasm_args_builder.clone().build())).unwrap();
+    let shard_opcode_size = 1000;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
+
+  #[test]
+  fn test_sharding_kth_factor() {
+    init_logger();
+    let step_size = StepSize::new(200).set_memory_step_size(50_000);
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/nebula/kth_factor.wat"))
+      .unwrap()
+      .func_args(vec!["250".to_string(), "15".to_string()])
+      .invoke("kth_factor");
+
+    let shard_opcode_size = 1000;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
+
+  #[test]
+  fn test_sharding_integer_hash() {
+    init_logger();
+    let step_size = StepSize::new(500).set_memory_step_size(50_000);
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/nebula/integer_hash.wasm"))
+      .unwrap()
+      .func_args(vec!["100".to_string()])
+      .invoke("integer_hash");
+
+    let shard_opcode_size = 2500;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
+
+  #[test]
+  fn test_sharding_gradient_boosting() {
+    init_logger();
+    let step_size = StepSize::new(1_000).set_memory_step_size(50_000);
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/gradient_boosting.wasm"))
+      .unwrap()
+      .invoke("_start");
+
+    let shard_opcode_size = 10_000;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
+
+  fn sim_nodes_and_orchestrator_node(
+    wasm_args_builder: &WASMArgsBuilder,
+    step_size: StepSize,
+    shard_opcode_size: usize,
+  ) {
+    /*
+     * ********** Node Network proving **********
+     */
+
+    // Public parameters used by [`WasmSNARK`]
+    let node_pp = WasmSNARK::<E>::setup(step_size);
+
+    // calculate number of shards from number of opcodes and shard opcode size
+    let num_shards = num_shards(
+      &WasiWASMCtx::new(wasm_args_builder.clone().build()),
+      shard_opcode_size,
+    );
+    tracing::info!("Number of shards: {num_shards}");
+    let node_snarks_and_instances = node_nw(
+      &node_pp,
+      wasm_args_builder,
+      num_shards,
+      step_size,
+      shard_opcode_size,
+    );
+
+    /*
+     * ********** Sharding proving (Orchestrator Node) **********
+     */
+
+    // Generate sharding public parameters
+    let sharding_pp = gen_sharding_pp(node_pp);
+
+    // Create a new instance of ShardingSNARK with the first node SNARK and instance
+    //
+    // # Note
+    //
+    // You will still need to pass in this first node SNARK and instance when proving sharding
+    let mut sharding_snark = ShardingSNARK::new(
+      &sharding_pp,
+      &node_snarks_and_instances[0].0,
+      &node_snarks_and_instances[0].1,
+    )
+    .unwrap();
+
+    // Prove sharding, aggregate all the node SNARKS into one
+    let sharding_proof_timer = start_timer!(format!("Proving Sharding"));
+    for (snark, U) in node_snarks_and_instances.iter() {
+      sharding_snark
+        .prove_sharding(&sharding_pp, &[snark.clone()], U)
+        .unwrap();
+    }
+    stop_timer!(sharding_proof_timer);
+
+    // Verify sharding was done correctly
+    sharding_snark.verify(&sharding_pp).unwrap();
+  }
+
+  fn num_shards(program: &impl ZKWASMCtx, shard_opcode_size: usize) -> usize {
+    let (trace, _, _, _) = estimate_wasm(program).unwrap();
     let trace_len = trace.len();
 
-    let num_shards = {
-      let mut res = trace_len / shard_opcode_size;
-      if trace_len % shard_opcode_size != 0 {
-        res += 1;
-      }
-      res
-    };
+    let mut num_shards = trace_len / shard_opcode_size;
+    // if there are remainder opcodes, add one more shard
+    if trace_len % shard_opcode_size != 0 {
+      num_shards += 1;
+    }
+    num_shards
+  }
+
+  fn node_nw(
+    node_pp: &WASMPublicParams<E>,
+    wasm_args_builder: &WASMArgsBuilder,
+    num_shards: usize,
+    step_size: StepSize,
+    shard_opcode_size: usize,
+  ) -> Vec<(WasmSNARK<E>, ZKWASMInstance<E>)> {
+    let mut start = 0;
+    let mut end = shard_opcode_size;
+    let mut snarks_and_instances: Vec<(WasmSNARK<E>, ZKWASMInstance<E>)> = Vec::new();
 
     for i in 0..num_shards {
-      let shard_proving_timer = start_timer!(format!("Proving Shard {i}"));
+      let shard_proving_timer = start_timer!(format!("Proving Shard {}/{}", i + 1, num_shards));
       let wasm_ctx = WasiWASMCtx::new(
         wasm_args_builder
           .clone()
@@ -133,29 +247,14 @@ mod tests {
           .build(),
       );
 
-      let (snark, U) = WasmSNARK::<E>::prove(&pp, wasm_ctx, step_size).unwrap();
-      snark.verify(&pp, &U).unwrap();
-      node_snarks.push((snark, U));
+      let (snark, U) = WasmSNARK::<E>::prove(node_pp, wasm_ctx, step_size).unwrap();
+      snark.verify(node_pp, &U).unwrap();
+      snarks_and_instances.push((snark, U));
       start = end;
       end += shard_opcode_size;
       stop_timer!(shard_proving_timer);
     }
 
-    let sharding_pp_timer = start_timer!("Producing sharding PP");
-    let sharding_pp = gen_sharding_pp(pp);
-    stop_timer!(sharding_pp_timer);
-
-    let mut sharding_snark =
-      ShardingSNARK::new(&sharding_pp, &node_snarks[0].0, &node_snarks[0].1).unwrap();
-
-    for (i, (snark, U)) in node_snarks.iter().enumerate() {
-      let sharding_proof_timer = start_timer!(format!("Proving Sharding: shard {i}"));
-      sharding_snark
-        .prove_sharding(&sharding_pp, &[snark.clone()], U)
-        .unwrap();
-      stop_timer!(sharding_proof_timer);
-    }
-
-    sharding_snark.verify(&sharding_pp).unwrap();
+    snarks_and_instances
   }
 }

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -11,6 +11,7 @@ use nova::{
   nebula::l2::sharding::{ShardingPublicParams, ShardingRecursiveSNARK},
   traits::CurveCycleEquipped,
 };
+use serde::{Deserialize, Serialize};
 #[cfg(test)]
 mod tests;
 
@@ -23,6 +24,7 @@ where
 }
 
 /// Sharding SNARK used to aggregate [`WasmSNARK`]'s
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ShardingSNARK<E>
 where
   E: CurveCycleEquipped,

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -37,6 +37,10 @@ where
   E: CurveCycleEquipped,
 {
   /// Create a new instance of [`ShardingSNARK`]
+  ///
+  /// # Note
+  ///
+  /// Input first shard here
   pub fn new(
     pp: &ShardingPublicParams<E>,
     wasm_snark: &WasmSNARK<E>,
@@ -51,6 +55,10 @@ where
   /// # Panics
   ///
   /// Panics if the number of [`WasmSNARK`]'s  and U's ([`ZKWASMInstance`]'s) are not equal
+  ///
+  /// # Note
+  ///
+  /// Order of shards inputted here matter.
   pub fn prove_sharding(
     &mut self,
     pp: &ShardingPublicParams<E>,

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -6,10 +6,14 @@ use super::{
   error::ZKWASMError,
   wasm_snark::{WASMPublicParams, WasmSNARK, ZKWASMInstance},
 };
+use itertools::Itertools;
 use nova::{
   nebula::l2::sharding::{ShardingPublicParams, ShardingRecursiveSNARK},
   traits::CurveCycleEquipped,
 };
+#[cfg(test)]
+mod tests;
+
 /// Generate sharding public parameters
 pub fn gen_sharding_pp<E>(wasm_pp: WASMPublicParams<E>) -> ShardingPublicParams<E>
 where
@@ -41,13 +45,17 @@ where
   }
 
   /// Combine the shards [`WasmSNARK`]s
+  ///
+  /// # Panics
+  ///
+  /// Panics if the number of [`WasmSNARK`]'s  and U's ([`ZKWASMInstance`]'s) are not equal
   pub fn prove_sharding(
     &mut self,
     pp: &ShardingPublicParams<E>,
     wasm_snarks: &[WasmSNARK<E>],
-    U: &ZKWASMInstance<E>,
+    U: &[ZKWASMInstance<E>],
   ) -> Result<(), ZKWASMError> {
-    for snark in wasm_snarks {
+    for (snark, U) in wasm_snarks.iter().zip_eq(U.iter()) {
       self.rs.prove_step(pp, snark, U)?;
     }
 
@@ -58,203 +66,5 @@ where
   pub fn verify(&self, pp: &ShardingPublicParams<E>) -> Result<(), ZKWASMError> {
     self.rs.verify(pp)?;
     Ok(())
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use nova::provider::Bn256EngineIPA;
-  use std::path::PathBuf;
-
-  use super::{gen_sharding_pp, ShardingSNARK};
-  use crate::{
-    utils::logging::init_logger,
-    v1::{
-      utils::{
-        macros::{start_timer, stop_timer},
-        tracing::estimate_wasm,
-      },
-      wasm_ctx::{TraceSliceValues, WASMArgsBuilder, WasiWASMCtx, ZKWASMCtx},
-      wasm_snark::{StepSize, WASMPublicParams, WasmSNARK, ZKWASMInstance},
-    },
-  };
-  use std::time::Instant;
-
-  /// Curve Cycle to prove/verify on
-  pub type E = Bn256EngineIPA;
-
-  #[test]
-  fn test_sharding_zk_ads() {
-    init_logger();
-    let step_size = StepSize::new(100).set_memory_step_size(50_000);
-    let input_x = "200.05";
-    let input_y = "-30.0";
-    let wasm_args_builder = WASMArgsBuilder::default()
-      .file_path(PathBuf::from("wasm/zk_ads.wasm"))
-      .unwrap()
-      .func_args(vec![
-        String::from("0"),
-        String::from(input_x),
-        String::from(input_y),
-      ])
-      .invoke("is_user_close_enough");
-
-    let shard_opcode_size = 500;
-    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-  }
-
-  #[test]
-  fn test_sharding_bulk_ops() {
-    init_logger();
-    let step_size = StepSize::new(200).set_memory_step_size(10_000);
-    let wasm_args_builder = WASMArgsBuilder::default()
-      .file_path(PathBuf::from("wasm/misc/bulk-ops.wat"))
-      .unwrap()
-      .func_args(vec!["200".to_string()]);
-
-    let shard_opcode_size = 1000;
-    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-  }
-
-  #[test]
-  fn test_sharding_kth_factor() {
-    init_logger();
-    let step_size = StepSize::new(200).set_memory_step_size(50_000);
-    let wasm_args_builder = WASMArgsBuilder::default()
-      .file_path(PathBuf::from("wasm/nebula/kth_factor.wat"))
-      .unwrap()
-      .func_args(vec!["250".to_string(), "15".to_string()])
-      .invoke("kth_factor");
-
-    let shard_opcode_size = 1000;
-    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-  }
-
-  #[test]
-  fn test_sharding_integer_hash() {
-    init_logger();
-    let step_size = StepSize::new(500).set_memory_step_size(50_000);
-    let wasm_args_builder = WASMArgsBuilder::default()
-      .file_path(PathBuf::from("wasm/nebula/integer_hash.wasm"))
-      .unwrap()
-      .func_args(vec!["100".to_string()])
-      .invoke("integer_hash");
-
-    let shard_opcode_size = 2500;
-    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-  }
-
-  #[test]
-  fn test_sharding_gradient_boosting() {
-    init_logger();
-    let step_size = StepSize::new(1_000).set_memory_step_size(50_000);
-    let wasm_args_builder = WASMArgsBuilder::default()
-      .file_path(PathBuf::from("wasm/gradient_boosting.wasm"))
-      .unwrap()
-      .invoke("_start");
-
-    let shard_opcode_size = 10_000;
-    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-  }
-
-  fn sim_nodes_and_orchestrator_node(
-    wasm_args_builder: &WASMArgsBuilder,
-    step_size: StepSize,
-    shard_opcode_size: usize,
-  ) {
-    /*
-     * ********** Node Network proving **********
-     */
-
-    // Public parameters used by [`WasmSNARK`]
-    let node_pp = WasmSNARK::<E>::setup(step_size);
-
-    // calculate number of shards from number of opcodes and shard opcode size
-    let num_shards = num_shards(
-      &WasiWASMCtx::new(wasm_args_builder.clone().build()),
-      shard_opcode_size,
-    );
-    tracing::info!("Number of shards: {num_shards}");
-    let node_snarks_and_instances = node_nw(
-      &node_pp,
-      wasm_args_builder,
-      num_shards,
-      step_size,
-      shard_opcode_size,
-    );
-
-    /*
-     * ********** Sharding proving (Orchestrator Node) **********
-     */
-
-    // Generate sharding public parameters
-    let sharding_pp = gen_sharding_pp(node_pp);
-
-    // Create a new instance of ShardingSNARK with the first node SNARK and instance
-    //
-    // # Note
-    //
-    // You will still need to pass in this first node SNARK and instance when proving sharding
-    let mut sharding_snark = ShardingSNARK::new(
-      &sharding_pp,
-      &node_snarks_and_instances[0].0,
-      &node_snarks_and_instances[0].1,
-    )
-    .unwrap();
-
-    // Prove sharding, aggregate all the node SNARKS into one
-    let sharding_proof_timer = start_timer!(format!("Proving Sharding"));
-    for (snark, U) in node_snarks_and_instances.iter() {
-      sharding_snark
-        .prove_sharding(&sharding_pp, &[snark.clone()], U)
-        .unwrap();
-    }
-    stop_timer!(sharding_proof_timer);
-
-    // Verify sharding was done correctly
-    sharding_snark.verify(&sharding_pp).unwrap();
-  }
-
-  fn num_shards(program: &impl ZKWASMCtx, shard_opcode_size: usize) -> usize {
-    let (trace, _, _, _) = estimate_wasm(program).unwrap();
-    let trace_len = trace.len();
-
-    let mut num_shards = trace_len / shard_opcode_size;
-    // if there are remainder opcodes, add one more shard
-    if trace_len % shard_opcode_size != 0 {
-      num_shards += 1;
-    }
-    num_shards
-  }
-
-  fn node_nw(
-    node_pp: &WASMPublicParams<E>,
-    wasm_args_builder: &WASMArgsBuilder,
-    num_shards: usize,
-    step_size: StepSize,
-    shard_opcode_size: usize,
-  ) -> Vec<(WasmSNARK<E>, ZKWASMInstance<E>)> {
-    let mut start = 0;
-    let mut end = shard_opcode_size;
-    let mut snarks_and_instances: Vec<(WasmSNARK<E>, ZKWASMInstance<E>)> = Vec::new();
-
-    for i in 0..num_shards {
-      let shard_proving_timer = start_timer!(format!("Proving Shard {}/{}", i + 1, num_shards));
-      let wasm_ctx = WasiWASMCtx::new(
-        wasm_args_builder
-          .clone()
-          .trace_slice(TraceSliceValues::new(start, end))
-          .build(),
-      );
-
-      let (snark, U) = WasmSNARK::<E>::prove(node_pp, wasm_ctx, step_size).unwrap();
-      snark.verify(node_pp, &U).unwrap();
-      snarks_and_instances.push((snark, U));
-      start = end;
-      end += shard_opcode_size;
-      stop_timer!(shard_proving_timer);
-    }
-
-    snarks_and_instances
   }
 }

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -43,7 +43,7 @@ where
   }
 
   /// Combine the shards [`WasmSNARK`]s
-  pub fn sharding(
+  pub fn prove_sharding(
     &mut self,
     pp: &ShardingPublicParams<E>,
     wasm_snarks: &[WasmSNARK<E>],

--- a/src/v1/sharding/tests.rs
+++ b/src/v1/sharding/tests.rs
@@ -1,0 +1,199 @@
+use nova::provider::Bn256EngineIPA;
+use std::path::PathBuf;
+
+use super::{gen_sharding_pp, ShardingSNARK};
+use crate::{
+  utils::logging::init_logger,
+  v1::{
+    utils::{
+      macros::{start_timer, stop_timer},
+      tracing::estimate_wasm,
+    },
+    wasm_ctx::{TraceSliceValues, WASMArgsBuilder, WasiWASMCtx, ZKWASMCtx},
+    wasm_snark::{StepSize, WASMPublicParams, WasmSNARK, ZKWASMInstance},
+  },
+};
+use std::time::Instant;
+
+/// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+#[test]
+fn test_sharding_zk_ads() {
+  init_logger();
+  let step_size = StepSize::new(100).set_memory_step_size(50_000);
+  let input_x = "200.05";
+  let input_y = "-30.0";
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+    .unwrap()
+    .func_args(vec![
+      String::from("0"),
+      String::from(input_x),
+      String::from(input_y),
+    ])
+    .invoke("is_user_close_enough");
+
+  let shard_opcode_size = 500;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+#[test]
+fn test_sharding_bulk_ops() {
+  init_logger();
+  let step_size = StepSize::new(200).set_memory_step_size(10_000);
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/bulk-ops.wat"))
+    .unwrap()
+    .func_args(vec!["200".to_string()]);
+
+  let shard_opcode_size = 1000;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+#[test]
+fn test_sharding_kth_factor() {
+  init_logger();
+  let step_size = StepSize::new(200).set_memory_step_size(50_000);
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/nebula/kth_factor.wat"))
+    .unwrap()
+    .func_args(vec!["250".to_string(), "15".to_string()])
+    .invoke("kth_factor");
+
+  let shard_opcode_size = 1000;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+#[test]
+fn test_sharding_integer_hash() {
+  init_logger();
+  let step_size = StepSize::new(500).set_memory_step_size(50_000);
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/nebula/integer_hash.wasm"))
+    .unwrap()
+    .func_args(vec!["100".to_string()])
+    .invoke("integer_hash");
+
+  let shard_opcode_size = 2500;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+#[test]
+fn test_sharding_gradient_boosting() {
+  init_logger();
+  let step_size = StepSize::new(1_000).set_memory_step_size(50_000);
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/gradient_boosting.wasm"))
+    .unwrap()
+    .invoke("_start");
+
+  let shard_opcode_size = 10_000;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+fn sim_nodes_and_orchestrator_node(
+  wasm_args_builder: &WASMArgsBuilder,
+  step_size: StepSize,
+  shard_opcode_size: usize,
+) {
+  /*
+   * ********** Node Network proving **********
+   */
+
+  // Public parameters used by [`WasmSNARK`]
+  //
+  // All nodes will use the same public parameters
+  let node_pp = WasmSNARK::<E>::setup(step_size);
+
+  // calculate number of shards from number of opcodes and shard opcode size
+  let num_shards = num_shards(
+    &WasiWASMCtx::new(wasm_args_builder.clone().build()),
+    shard_opcode_size,
+  );
+  tracing::info!("Number of shards: {num_shards}");
+  let (node_snarks, node_instances) = node_nw(
+    &node_pp,
+    wasm_args_builder,
+    num_shards,
+    step_size,
+    shard_opcode_size,
+  );
+
+  /*
+   * ********** Sharding proving (Orchestrator Node work) **********
+   */
+
+  // Generate sharding public parameters
+  //
+  // This is the public parameters used by the orchestrator node
+  let sharding_pp = gen_sharding_pp(node_pp);
+
+  // Create a new instance of ShardingSNARK with the first node SNARK and instance
+  //
+  // # Note
+  //
+  // * You will still need to pass in this first node SNARK and instance when proving sharding
+  //
+  // * This SNARK will testify that all node SNARKs are correct
+  let mut sharding_snark =
+    ShardingSNARK::new(&sharding_pp, &node_snarks[0], &node_instances[0]).unwrap();
+
+  // Prove sharding,
+  // i.e do some checks and aggregate all the node SNARKS into one
+  let sharding_proof_timer = start_timer!(format!("Proving Sharding"));
+  sharding_snark
+    .prove_sharding(&sharding_pp, &node_snarks, &node_instances)
+    .unwrap();
+  stop_timer!(sharding_proof_timer);
+
+  // Verify sharding was done correctly
+  sharding_snark.verify(&sharding_pp).unwrap();
+}
+
+fn num_shards(program: &impl ZKWASMCtx, shard_opcode_size: usize) -> usize {
+  let (trace, _, _, _) = estimate_wasm(program).unwrap();
+  let trace_len = trace.len();
+
+  let mut num_shards = trace_len / shard_opcode_size;
+  // if there are remainder opcodes, add one more shard
+  if trace_len % shard_opcode_size != 0 {
+    num_shards += 1;
+  }
+  num_shards
+}
+
+fn node_nw(
+  node_pp: &WASMPublicParams<E>,
+  wasm_args_builder: &WASMArgsBuilder,
+  num_shards: usize,
+  step_size: StepSize,
+  shard_opcode_size: usize,
+) -> (Vec<WasmSNARK<E>>, Vec<ZKWASMInstance<E>>) {
+  let mut start = 0;
+  let mut end = shard_opcode_size;
+  let mut node_snarks = Vec::new();
+  let mut node_instances = Vec::new();
+
+  for i in 0..num_shards {
+    let shard_proving_timer = start_timer!(format!("Proving Shard {}/{}", i + 1, num_shards));
+    let wasm_ctx = WasiWASMCtx::new(
+      wasm_args_builder
+        .clone()
+        .trace_slice(TraceSliceValues::new(start, end))
+        .build(),
+    );
+
+    let (snark, U) = WasmSNARK::<E>::prove(node_pp, &wasm_ctx, step_size).unwrap();
+    snark.verify(node_pp, &U).unwrap();
+
+    node_snarks.push(snark);
+    node_instances.push(U);
+
+    start = end;
+    end += shard_opcode_size;
+    stop_timer!(shard_proving_timer);
+  }
+
+  (node_snarks, node_instances)
+}

--- a/src/v1/sharding/tests.rs
+++ b/src/v1/sharding/tests.rs
@@ -1,6 +1,3 @@
-use nova::provider::Bn256EngineIPA;
-use std::path::PathBuf;
-
 use super::{gen_sharding_pp, ShardingSNARK};
 use crate::{
   utils::logging::init_logger,
@@ -13,8 +10,8 @@ use crate::{
     wasm_snark::{StepSize, WASMPublicParams, WasmSNARK, ZKWASMInstance},
   },
 };
-use nova::nebula::l2::sharding::MemoryCommitmentsTraits;
-use std::time::Instant;
+use nova::provider::Bn256EngineIPA;
+use std::{path::PathBuf, time::Instant};
 
 /// Curve Cycle to prove/verify on
 pub type E = Bn256EngineIPA;
@@ -96,66 +93,6 @@ fn test_sharding_integer_hash() {
 }
 
 #[test]
-fn test_sharding_zk_ads_mismatch() {
-  init_logger();
-  let step_size = StepSize::new(100).set_memory_step_size(50_000);
-  let input_x = "200.05";
-  let input_y = "-30.0";
-  let wasm_args_builder = WASMArgsBuilder::default()
-    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
-    .unwrap()
-    .func_args(vec![
-      String::from("0"),
-      String::from(input_x),
-      String::from(input_y),
-    ])
-    .invoke("is_user_close_enough");
-
-  let shard_opcode_size = 499;
-  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-}
-
-#[test]
-fn test_sharding_zk_ads_mismatch2() {
-  init_logger();
-  let step_size = StepSize::new(99).set_memory_step_size(50_000);
-  let input_x = "200.05";
-  let input_y = "-30.0";
-  let wasm_args_builder = WASMArgsBuilder::default()
-    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
-    .unwrap()
-    .func_args(vec![
-      String::from("0"),
-      String::from(input_x),
-      String::from(input_y),
-    ])
-    .invoke("is_user_close_enough");
-
-  let shard_opcode_size = 500;
-  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-}
-
-#[test]
-fn test_sharding_zk_ads_mismatch3() {
-  init_logger();
-  let step_size = StepSize::new(177).set_memory_step_size(50_000);
-  let input_x = "200.05";
-  let input_y = "-30.0";
-  let wasm_args_builder = WASMArgsBuilder::default()
-    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
-    .unwrap()
-    .func_args(vec![
-      String::from("0"),
-      String::from(input_x),
-      String::from(input_y),
-    ])
-    .invoke("is_user_close_enough");
-
-  let shard_opcode_size = 1011;
-  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
-}
-
-#[test]
 fn test_sharding_gradient_boosting() {
   init_logger();
   let step_size = StepSize::new(1_000).set_memory_step_size(50_000);
@@ -228,7 +165,7 @@ fn sim_nodes_and_orchestrator_node(
 }
 
 fn num_shards(program: &impl ZKWASMCtx, shard_opcode_size: usize) -> usize {
-  let (trace, _, _, _) = estimate_wasm(program).unwrap();
+  let (trace, _, _) = estimate_wasm(program).unwrap();
   let trace_len = trace.len();
 
   let mut num_shards = trace_len / shard_opcode_size;
@@ -272,4 +209,68 @@ fn node_nw(
   }
 
   (node_snarks, node_instances)
+}
+
+mod test_mismatches {
+  use super::*;
+
+  #[test]
+  fn test_sharding_zk_ads_mismatch1() {
+    init_logger();
+    let step_size = StepSize::new(100).set_memory_step_size(50_000);
+    let input_x = "200.05";
+    let input_y = "-30.0";
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+      .unwrap()
+      .func_args(vec![
+        String::from("0"),
+        String::from(input_x),
+        String::from(input_y),
+      ])
+      .invoke("is_user_close_enough");
+
+    let shard_opcode_size = 499;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
+
+  #[test]
+  fn test_sharding_zk_ads_mismatch2() {
+    init_logger();
+    let step_size = StepSize::new(99).set_memory_step_size(50_000);
+    let input_x = "200.05";
+    let input_y = "-30.0";
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+      .unwrap()
+      .func_args(vec![
+        String::from("0"),
+        String::from(input_x),
+        String::from(input_y),
+      ])
+      .invoke("is_user_close_enough");
+
+    let shard_opcode_size = 500;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
+
+  #[test]
+  fn test_sharding_zk_ads_mismatch3() {
+    init_logger();
+    let step_size = StepSize::new(177).set_memory_step_size(50_000);
+    let input_x = "200.05";
+    let input_y = "-30.0";
+    let wasm_args_builder = WASMArgsBuilder::default()
+      .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+      .unwrap()
+      .func_args(vec![
+        String::from("0"),
+        String::from(input_x),
+        String::from(input_y),
+      ])
+      .invoke("is_user_close_enough");
+
+    let shard_opcode_size = 1011;
+    sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+  }
 }

--- a/src/v1/sharding/tests.rs
+++ b/src/v1/sharding/tests.rs
@@ -81,14 +81,14 @@ fn test_sharding_kth_factor() {
 #[test]
 fn test_sharding_integer_hash() {
   init_logger();
-  let step_size = StepSize::new(500).set_memory_step_size(50_000);
+  let step_size = StepSize::new(1_000).set_memory_step_size(50_000);
   let wasm_args_builder = WASMArgsBuilder::default()
     .file_path(PathBuf::from("wasm/nebula/integer_hash.wasm"))
     .unwrap()
     .func_args(vec!["100".to_string()])
     .invoke("integer_hash");
 
-  let shard_opcode_size = 2500;
+  let shard_opcode_size = 10_000;
   sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
 }
 

--- a/src/v1/sharding/tests.rs
+++ b/src/v1/sharding/tests.rs
@@ -13,10 +13,26 @@ use crate::{
     wasm_snark::{StepSize, WASMPublicParams, WasmSNARK, ZKWASMInstance},
   },
 };
+use nova::nebula::l2::sharding::MemoryCommitmentsTraits;
 use std::time::Instant;
 
 /// Curve Cycle to prove/verify on
 pub type E = Bn256EngineIPA;
+
+#[test]
+fn test_sharding_eq_func_mismatch() {
+  init_logger();
+  let step_size = StepSize::new(100);
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/nebula/eq_func.wat"))
+    .unwrap()
+    .invoke("eq_func")
+    .func_args(vec!["255".to_string(), "255".to_string()]);
+
+  let shard_opcode_size = 499;
+
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
 
 #[test]
 fn test_sharding_zk_ads() {
@@ -76,6 +92,66 @@ fn test_sharding_integer_hash() {
     .invoke("integer_hash");
 
   let shard_opcode_size = 2500;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+#[test]
+fn test_sharding_zk_ads_mismatch() {
+  init_logger();
+  let step_size = StepSize::new(100).set_memory_step_size(50_000);
+  let input_x = "200.05";
+  let input_y = "-30.0";
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+    .unwrap()
+    .func_args(vec![
+      String::from("0"),
+      String::from(input_x),
+      String::from(input_y),
+    ])
+    .invoke("is_user_close_enough");
+
+  let shard_opcode_size = 499;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+#[test]
+fn test_sharding_zk_ads_mismatch2() {
+  init_logger();
+  let step_size = StepSize::new(99).set_memory_step_size(50_000);
+  let input_x = "200.05";
+  let input_y = "-30.0";
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+    .unwrap()
+    .func_args(vec![
+      String::from("0"),
+      String::from(input_x),
+      String::from(input_y),
+    ])
+    .invoke("is_user_close_enough");
+
+  let shard_opcode_size = 500;
+  sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
+}
+
+#[test]
+fn test_sharding_zk_ads_mismatch3() {
+  init_logger();
+  let step_size = StepSize::new(177).set_memory_step_size(50_000);
+  let input_x = "200.05";
+  let input_y = "-30.0";
+  let wasm_args_builder = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/zk_ads.wasm"))
+    .unwrap()
+    .func_args(vec![
+      String::from("0"),
+      String::from(input_x),
+      String::from(input_y),
+    ])
+    .invoke("is_user_close_enough");
+
+  let shard_opcode_size = 1011;
   sim_nodes_and_orchestrator_node(&wasm_args_builder, step_size, shard_opcode_size);
 }
 

--- a/src/v1/tests.rs
+++ b/src/v1/tests.rs
@@ -22,7 +22,7 @@ fn test_wasm_snark_with(wasm_ctx: impl ZKWASMCtx, step_size: StepSize) -> Result
   stop_timer!(pp_timer);
 
   let proving_timer = start_timer!("Producing WasmSNARK");
-  let (snark, U) = WasmSNARK::<E>::prove(&pp, wasm_ctx, step_size)?;
+  let (snark, U) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
   stop_timer!(proving_timer);
 
   let verification_timer = start_timer!("Verifying WasmSNARK");

--- a/src/v1/tests.rs
+++ b/src/v1/tests.rs
@@ -1,17 +1,14 @@
-use std::{path::PathBuf, time::Instant};
-
-use nova::provider::Bn256EngineIPA;
-
-use crate::{
-  utils::logging::init_logger,
-  v1::utils::macros::{start_timer, stop_timer},
-};
-
 use super::{
   error::ZKWASMError,
   wasm_ctx::{TraceSliceValues, WASMArgsBuilder, WASMCtx, WasiWASMCtx, ZKWASMCtx},
   wasm_snark::{StepSize, WasmSNARK},
 };
+use crate::{
+  utils::logging::init_logger,
+  v1::utils::macros::{start_timer, stop_timer},
+};
+use nova::provider::Bn256EngineIPA;
+use std::{path::PathBuf, time::Instant};
 
 /// Curve Cycle to prove/verify on
 pub type E = Bn256EngineIPA;

--- a/src/v1/tests.rs
+++ b/src/v1/tests.rs
@@ -213,3 +213,35 @@ fn test_bls() -> Result<(), ZKWASMError> {
 
   Ok(())
 }
+
+#[test]
+fn test_fib_large() -> Result<(), ZKWASMError> {
+  let step_size = StepSize::new(1_000);
+  init_logger();
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))?
+    .invoke("fib")
+    .func_args(vec![String::from("1000")])
+    .build();
+
+  let wasm_ctx = WASMCtx::new(wasm_args);
+  test_wasm_snark_with(wasm_ctx, step_size)?;
+
+  Ok(())
+}
+
+#[test]
+fn test_fib_small() -> Result<(), ZKWASMError> {
+  let step_size = StepSize::new(10);
+  init_logger();
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))?
+    .invoke("fib")
+    .func_args(vec![String::from("16")])
+    .build();
+
+  let wasm_ctx = WASMCtx::new(wasm_args);
+  test_wasm_snark_with(wasm_ctx, step_size)?;
+
+  Ok(())
+}

--- a/src/v1/tests.rs
+++ b/src/v1/tests.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::{
   error::ZKWASMError,
-  wasm_ctx::{WASMArgsBuilder, WASMCtx, WasiWASMCtx, ZKWASMCtx},
+  wasm_ctx::{TraceSliceValues, WASMArgsBuilder, WASMCtx, WasiWASMCtx, ZKWASMCtx},
   wasm_snark::{StepSize, WasmSNARK},
 };
 
@@ -202,15 +202,17 @@ fn test_uni_poly_eval() {
 }
 
 #[test]
-fn test_bls() {
+fn test_bls() -> Result<(), ZKWASMError> {
   let step_size = StepSize::new(1_000).set_memory_step_size(50_000);
   init_logger();
   let wasm_args = WASMArgsBuilder::default()
     .file_path(PathBuf::from("wasm/bls.wasm"))
     .unwrap()
-    .end_slice(10_000)
+    .trace_slice(TraceSliceValues::new(10_000, 20_000))
     .build();
 
   let wasm_ctx = WASMCtx::new(wasm_args);
-  test_wasm_snark_with(wasm_ctx, step_size).unwrap();
+  test_wasm_snark_with(wasm_ctx, step_size)?;
+
+  Ok(())
 }

--- a/src/v1/utils/mod.rs
+++ b/src/v1/utils/mod.rs
@@ -1,2 +1,3 @@
+#[cfg(test)]
 pub mod macros;
 pub mod tracing;

--- a/src/v1/utils/tracing.rs
+++ b/src/v1/utils/tracing.rs
@@ -1,4 +1,7 @@
-use crate::v1::{error::ZKWASMError, wasm_ctx::ZKWASMCtx};
+use crate::v1::{
+  error::ZKWASMError,
+  wasm_ctx::{ExecutionTrace, ZKWASMCtx},
+};
 use std::{cell::RefCell, rc::Rc, time::Instant};
 
 use super::macros::{start_timer, stop_timer};
@@ -15,12 +18,10 @@ pub fn unwrap_rc_refcell<T>(last_elem: Rc<RefCell<T>>) -> T {
 }
 
 #[allow(dead_code)]
+#[tracing::instrument(skip_all, name = "estimate_wasm")]
 /// Get estimations of the WASM execution trace size
-pub fn estimate_wasm(program: impl ZKWASMCtx) -> Result<(), ZKWASMError> {
-  let execution_timer = start_timer!("Running WASM");
-  let _ = program.execution_trace()?;
-  stop_timer!(execution_timer);
-  Ok(())
+pub fn estimate_wasm(program: impl ZKWASMCtx) -> Result<ExecutionTrace, ZKWASMError> {
+  program.execution_trace()
 }
 
 /// Split vector and return Vec's

--- a/src/v1/utils/tracing.rs
+++ b/src/v1/utils/tracing.rs
@@ -2,9 +2,7 @@ use crate::v1::{
   error::ZKWASMError,
   wasm_ctx::{ExecutionTrace, ZKWASMCtx},
 };
-use std::{cell::RefCell, rc::Rc, time::Instant};
-
-use super::macros::{start_timer, stop_timer};
+use std::{cell::RefCell, rc::Rc};
 
 /// Get inner value of [`Rc<RefCell<T>>`]
 ///

--- a/src/v1/utils/tracing.rs
+++ b/src/v1/utils/tracing.rs
@@ -20,7 +20,7 @@ pub fn unwrap_rc_refcell<T>(last_elem: Rc<RefCell<T>>) -> T {
 #[allow(dead_code)]
 #[tracing::instrument(skip_all, name = "estimate_wasm")]
 /// Get estimations of the WASM execution trace size
-pub fn estimate_wasm(program: impl ZKWASMCtx) -> Result<ExecutionTrace, ZKWASMError> {
+pub fn estimate_wasm(program: &impl ZKWASMCtx) -> Result<ExecutionTrace, ZKWASMError> {
   program.execution_trace()
 }
 

--- a/src/v1/utils/tracing.rs
+++ b/src/v1/utils/tracing.rs
@@ -22,3 +22,9 @@ pub fn estimate_wasm(program: impl ZKWASMCtx) -> Result<(), ZKWASMError> {
   stop_timer!(execution_timer);
   Ok(())
 }
+
+/// Split vector and return Vec's
+pub fn split_vector<T>(mut vec: Vec<T>, split_index: usize) -> (Vec<T>, Vec<T>) {
+  let second_part = vec.split_off(split_index);
+  (vec, second_part)
+}

--- a/src/v1/wasm_ctx.rs
+++ b/src/v1/wasm_ctx.rs
@@ -5,12 +5,13 @@ use crate::{
   v1::utils::tracing::unwrap_rc_refcell,
 };
 use rand::{rngs::StdRng, RngCore, SeedableRng};
+use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, path::PathBuf, rc::Rc};
 use wasmi::{Tracer, WitnessVM};
 use wasmi_wasi::{clocks_ctx, sched_ctx, Table, WasiCtx};
 
 /// Builder for [`WASMCtx`]. Defines the WASM execution context that will be used for proving
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WASMArgsBuilder {
   program: Vec<u8>,
   invoke: String,
@@ -63,7 +64,7 @@ impl WASMArgsBuilder {
 }
 
 /// WASM execution context: contains the WASM program and its [`WASMCtxMetaData`]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WASMArgs {
   pub(in crate::v1) program: Vec<u8>,
   pub(in crate::v1) invoke: String,
@@ -103,7 +104,7 @@ impl Default for WASMArgsBuilder {
 }
 
 /// Used to set start and end values to slice execution trace. Used in sharding/continuations
-#[derive(Debug, Clone, Default, Copy)]
+#[derive(Debug, Clone, Default, Copy, Serialize, Deserialize)]
 pub struct TraceSliceValues {
   /// Start opcode
   pub(crate) start: usize,

--- a/src/v1/wasm_ctx.rs
+++ b/src/v1/wasm_ctx.rs
@@ -10,7 +10,7 @@ use wasmi::{Tracer, WitnessVM};
 use wasmi_wasi::{clocks_ctx, sched_ctx, Table, WasiCtx};
 
 /// Builder for [`WASMCtx`]. Defines the WASM execution context that will be used for proving
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WASMArgsBuilder {
   program: Vec<u8>,
   invoke: String,
@@ -134,7 +134,7 @@ impl TraceSliceValues {
 }
 
 /// Execution trace, Initial memory trace, Initial stack trace length, Initial linear memory length
-type ExecutionTrace = (Vec<WitnessVM>, Vec<(usize, u64, u64)>, usize, usize);
+pub type ExecutionTrace = (Vec<WitnessVM>, Vec<(usize, u64, u64)>, usize, usize);
 
 /// Definition for WASM execution context
 pub trait ZKWASMCtx {

--- a/src/v1/wasm_ctx.rs
+++ b/src/v1/wasm_ctx.rs
@@ -79,6 +79,11 @@ impl WASMArgs {
       .map(|val| val.start())
       .unwrap_or_default()
   }
+
+  /// Get the shard_size
+  pub fn shard_size(&self) -> Option<usize> {
+    self.trace_slice_vals.map(|val| val.shard_size())
+  }
 }
 
 impl Default for WASMArgsBuilder {
@@ -130,6 +135,11 @@ impl TraceSliceValues {
   /// Setter for end value
   pub fn set_end(&mut self, end: usize) {
     self.end = end;
+  }
+
+  /// Calculate the shard_size
+  pub fn shard_size(&self) -> usize {
+    self.end - self.start
   }
 }
 

--- a/src/v1/wasm_snark/mcc/tests.rs
+++ b/src/v1/wasm_snark/mcc/tests.rs
@@ -40,7 +40,7 @@ where
 
   // Compute multisets to perform grand product checks (uses global_ts)
 
-  let (execution_trace, IS, IS_stack_len, IS_mem_len) = program.execution_trace()?;
+  let (execution_trace, IS, IS_sizes) = program.execution_trace()?;
 
   let mut RS: Vec<(usize, u64, u64)> = Vec::new();
   let mut WS: Vec<(usize, u64, u64)> = Vec::new();
@@ -51,7 +51,7 @@ where
 
   // Build the WASMTransitionCircuit from each traced execution frame.
   execution_trace.into_iter().for_each(|vm| {
-    let (step_rs, step_ws) = step_RS_WS(&vm, &mut FS, &mut global_ts, IS_stack_len, IS_mem_len);
+    let (step_rs, step_ws) = step_RS_WS(&vm, &mut FS, &mut global_ts, &IS_sizes);
 
     RS.extend(step_rs);
     WS.extend(step_ws);

--- a/src/v1/wasm_snark/mod.rs
+++ b/src/v1/wasm_snark/mod.rs
@@ -37,6 +37,7 @@ mod mcc;
 pub const MEMORY_OPS_PER_STEP: usize = 8;
 
 /// Public i/o for WASM execution proving
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ZKWASMInstance<E>
 where
   E: CurveCycleEquipped,
@@ -70,6 +71,7 @@ where
 }
 
 /// [`WasmSNARK`] public parameters
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WASMPublicParams<E>
 where
   E: CurveCycleEquipped,

--- a/src/v1/wasm_snark/mod.rs
+++ b/src/v1/wasm_snark/mod.rs
@@ -157,7 +157,7 @@ where
   /// Produce a SNARK for WASM program input
   pub fn prove(
     pp: &WASMPublicParams<E>,
-    program: impl ZKWASMCtx,
+    program: &impl ZKWASMCtx,
     step_size: StepSize,
   ) -> Result<(Self, ZKWASMInstance<E>), ZKWASMError> {
     // We maintain a timestamp counter `globa_ts` that is initialized to


### PR DESCRIPTION
This PR introduces **aggregation** and **sharding** via Nebula (Section 4.4.3: folding of RecursiveSNARKs). The two main additions to the API are `AggregationSNARK` and `ShardingSNARK`.  

- Both SNARKS expose a method that takes in node SNARKs from **Ground Proving Nodes (GPNs)** and folds them into a single SNARK.  
- The resulting SNARK testifies that all GPN SNARKs are valid (NOTE: this resulting SNARK has a verify method).  

To demonstrate how to use this API, refer to the tests provided in the `v1/aggregation` and `v1/sharding` folders. The examples are relatively straightforward and aim to simplify integration.  