### PR TITLE
fix: serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula#cd2e7c20d7d23131a446e2312da906f3b9d10c49"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula#b92375adc4927897822fe73f48c7735af2a4b8b7"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,7 @@ path = "examples/v1/fib_large.rs"
 [[example]]
 name = "kth_factor"
 path = "examples/v1/kth_factor.rs"
+
+[[example]]
+name = "fib_serde"
+path = "examples/v1/fib_serde.rs"

--- a/examples/v1/fib_serde.rs
+++ b/examples/v1/fib_serde.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+use zk_engine::{
+  nova::provider::Bn256EngineIPA,
+  utils::logging::init_logger,
+  v1::{
+    error::ZKWASMError,
+    wasm_ctx::{WASMArgsBuilder, WASMCtx},
+    wasm_snark::{StepSize, WasmSNARK, ZKWASMInstance},
+  },
+};
+
+// Curve Cycle to prove/verify on
+pub type E = Bn256EngineIPA;
+
+fn main() -> Result<(), ZKWASMError> {
+  init_logger();
+
+  // Specify step size.
+  //
+  // Here we choose `10` as the step size because the wasm execution of fib(16) is 253 opcodes.
+  // meaning zkWASM will run for 26 steps (rounds up).
+  let step_size = StepSize::new(10);
+
+  // Produce setup material
+  let pp = WasmSNARK::<E>::setup(step_size);
+
+  // Specify arguments to the WASM and use it to build a `WASMCtx`
+  let wasm_args = WASMArgsBuilder::default()
+    .file_path(PathBuf::from("wasm/misc/fib.wat"))
+    .unwrap()
+    .invoke("fib")
+    .func_args(vec![String::from("16")])
+    .build();
+  let wasm_ctx = WASMCtx::new(wasm_args);
+
+  // Prove wasm execution of fib.wat::fib(16)
+  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+
+  let str_instance = serde_json::to_string(&instance).unwrap();
+  let str_snark = serde_json::to_string(&snark).unwrap();
+
+  let snark: WasmSNARK<E> = serde_json::from_str(&str_snark).unwrap();
+  let instance: ZKWASMInstance<E> = serde_json::from_str(&str_instance).unwrap();
+
+  // Verify the proof
+  snark.verify(&pp, &instance)?;
+
+  Ok(())
+}

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -23,6 +23,7 @@ where
 
 /// Aggregation SNARK used to aggregate [`WasmSNARK`]'s
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct AggregationSNARK<E>
 where
   E: CurveCycleEquipped,

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -5,6 +5,6 @@ pub mod error;
 pub mod sharding;
 #[cfg(test)]
 mod tests;
-mod utils;
+pub mod utils;
 pub mod wasm_ctx;
 pub mod wasm_snark;

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -25,6 +25,7 @@ where
 
 /// Sharding SNARK used to aggregate [`WasmSNARK`]'s
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct ShardingSNARK<E>
 where
   E: CurveCycleEquipped,

--- a/src/v1/utils/mod.rs
+++ b/src/v1/utils/mod.rs
@@ -1,3 +1,5 @@
+//! Utility code
+
 #[cfg(test)]
 pub mod macros;
 pub mod tracing;

--- a/src/v1/utils/tracing.rs
+++ b/src/v1/utils/tracing.rs
@@ -11,7 +11,7 @@ use std::{cell::RefCell, rc::Rc};
 /// # Panics
 ///
 /// Panics if [`Rc`] is not the sole owner of the underlying data,
-pub fn unwrap_rc_refcell<T>(last_elem: Rc<RefCell<T>>) -> T {
+pub(crate) fn unwrap_rc_refcell<T>(last_elem: Rc<RefCell<T>>) -> T {
   let inner: RefCell<T> = Rc::try_unwrap(last_elem)
     .unwrap_or_else(|_| panic!("The last_elem was shared, failed to unwrap"));
   inner.into_inner()
@@ -25,7 +25,7 @@ pub fn estimate_wasm(program: &impl ZKWASMCtx) -> Result<ExecutionTrace, ZKWASME
 }
 
 /// Split vector and return Vec's
-pub fn split_vector<T>(mut vec: Vec<T>, split_index: usize) -> (Vec<T>, Vec<T>) {
+pub(crate) fn split_vector<T>(mut vec: Vec<T>, split_index: usize) -> (Vec<T>, Vec<T>) {
   let second_part = vec.split_off(split_index);
   (vec, second_part)
 }

--- a/src/v1/utils/tracing.rs
+++ b/src/v1/utils/tracing.rs
@@ -1,3 +1,5 @@
+//! Utility code
+
 use crate::v1::{
   error::ZKWASMError,
   wasm_ctx::{ExecutionTrace, ZKWASMCtx},

--- a/src/v1/wasm_ctx.rs
+++ b/src/v1/wasm_ctx.rs
@@ -90,6 +90,11 @@ impl WASMArgs {
   pub fn shard_size(&self) -> Option<usize> {
     self.trace_slice_vals.map(|val| val.shard_size())
   }
+
+  /// Get clone of bytecode.
+  pub fn bytecode(&self) -> Vec<u8> {
+    self.program.clone()
+  }
 }
 
 impl Default for WASMArgsBuilder {

--- a/src/v1/wasm_ctx.rs
+++ b/src/v1/wasm_ctx.rs
@@ -91,9 +91,9 @@ impl WASMArgs {
     self.trace_slice_vals.map(|val| val.shard_size())
   }
 
-  /// Get clone of bytecode.
-  pub fn bytecode(&self) -> Vec<u8> {
-    self.program.clone()
+  /// Get reference to bytecode.
+  pub fn bytecode(&self) -> &[u8] {
+    &self.program
   }
 }
 

--- a/src/v1/wasm_snark/mod.rs
+++ b/src/v1/wasm_snark/mod.rs
@@ -38,6 +38,7 @@ pub const MEMORY_OPS_PER_STEP: usize = 8;
 
 /// Public i/o for WASM execution proving
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct ZKWASMInstance<E>
 where
   E: CurveCycleEquipped,
@@ -72,6 +73,7 @@ where
 
 /// [`WasmSNARK`] public parameters
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct WASMPublicParams<E>
 where
   E: CurveCycleEquipped,
@@ -117,6 +119,7 @@ where
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
 /// A SNARK that proves the correct execution of a WASM modules execution
 pub struct WasmSNARK<E>
 where


### PR DESCRIPTION
* Follow Nova codebase API design by adding `#[serde(bound = "")]` to the public types used in proving/verifying

* Added ser/de example as well:` RUST_LOG=debug cargo +nightly run --release --example fib_serde`
