### PR TITLE
Feat/compressed snark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#7e41b973b589b59b7cf58988391fe245f2351fd7"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#b395ec79739b9b7ccfd2547e850f5766cbd10240"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#b395ec79739b9b7ccfd2547e850f5766cbd10240"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#8c79d26fbba38c08794841409e6bb4e24f6c65c0"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#b50a9b0d9086bd2a947d93eda1e8865d9be40670"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula#2afae7ac35dc685e3da4d8dc0adc4c7c2d891e91"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#51bb52b50fb8c5f3623c0fc575a348ca946d3cb0"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#7e41b973b589b59b7cf58988391fe245f2351fd7"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#8c79d26fbba38c08794841409e6bb4e24f6c65c0"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#b50a9b0d9086bd2a947d93eda1e8865d9be40670"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 [[package]]
 name = "arecibo"
 version = "0.2.0"
-source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fnebula#b92375adc4927897822fe73f48c7735af2a4b8b7"
+source = "git+https://github.com/wyattbenno777/arecibo?branch=feat%2Fupdate-backend#51bb52b50fb8c5f3623c0fc575a348ca946d3cb0"
 dependencies = [
  "abomonation",
  "abomonation_derive_ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 wasmi = { path = "./third-party/wasmi/crates/wasmi" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/update-backend", package = "arecibo" }
+nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/nebula", package = "arecibo" }
 bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bellpepper-core = { version = "0.4.0", default-features = false }
 ff = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 wasmi = { path = "./third-party/wasmi/crates/wasmi" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/nebula", package = "arecibo" }
+nova = { git = "https://github.com/wyattbenno777/arecibo", branch = "feat/update-backend", package = "arecibo" }
 bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bellpepper-core = { version = "0.4.0", default-features = false }
 ff = "0.13"

--- a/examples/v1/fib.rs
+++ b/examples/v1/fib.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
 use zk_engine::{
-  nova::provider::Bn256EngineIPA,
+  nova::{
+    provider::{ipa_pc, Bn256EngineIPA},
+    spartan,
+    traits::Dual,
+  },
   utils::logging::init_logger,
   v1::{
     error::ZKWASMError,
@@ -11,6 +15,10 @@ use zk_engine::{
 
 // Curve Cycle to prove/verify on
 pub type E = Bn256EngineIPA;
+pub type EE1 = ipa_pc::EvaluationEngine<E>;
+pub type EE2 = ipa_pc::EvaluationEngine<Dual<E>>;
+pub type S1 = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE1>;
+pub type S2 = spartan::batched::BatchedRelaxedR1CSSNARK<Dual<E>, EE2>;
 
 fn main() -> Result<(), ZKWASMError> {
   init_logger();
@@ -22,7 +30,7 @@ fn main() -> Result<(), ZKWASMError> {
   let step_size = StepSize::new(10);
 
   // Produce setup material
-  let pp = WasmSNARK::<E>::setup(step_size);
+  let pp = WasmSNARK::<E, S1, S2>::setup(step_size);
 
   // Specify arguments to the WASM and use it to build a `WASMCtx`
   let wasm_args = WASMArgsBuilder::default()
@@ -34,7 +42,7 @@ fn main() -> Result<(), ZKWASMError> {
   let wasm_ctx = WASMCtx::new(wasm_args);
 
   // Prove wasm execution of fib.wat::fib(16)
-  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+  let (snark, instance) = WasmSNARK::<E, S1, S2>::prove(&pp, &wasm_ctx, step_size)?;
 
   // Verify the proof
   snark.verify(&pp, &instance)?;

--- a/examples/v1/fib_large.rs
+++ b/examples/v1/fib_large.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
 use zk_engine::{
-  nova::provider::Bn256EngineIPA,
+  nova::{
+    provider::{ipa_pc, Bn256EngineIPA},
+    spartan,
+    traits::Dual,
+  },
   utils::logging::init_logger,
   v1::{
     error::ZKWASMError,
@@ -11,6 +15,10 @@ use zk_engine::{
 
 // Curve Cycle to prove/verify on
 pub type E = Bn256EngineIPA;
+pub type EE1 = ipa_pc::EvaluationEngine<E>;
+pub type EE2 = ipa_pc::EvaluationEngine<Dual<E>>;
+pub type S1 = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE1>;
+pub type S2 = spartan::batched::BatchedRelaxedR1CSSNARK<Dual<E>, EE2>;
 
 fn main() -> Result<(), ZKWASMError> {
   init_logger();
@@ -22,7 +30,7 @@ fn main() -> Result<(), ZKWASMError> {
   let step_size = StepSize::new(1_000);
 
   // Produce setup material
-  let pp = WasmSNARK::<E>::setup(step_size);
+  let pp = WasmSNARK::<E, S1, S2>::setup(step_size);
 
   // Specify arguments to the WASM and use it to build a `WASMCtx`
   let wasm_args = WASMArgsBuilder::default()
@@ -34,7 +42,7 @@ fn main() -> Result<(), ZKWASMError> {
   let wasm_ctx = WASMCtx::new(wasm_args);
 
   // Prove wasm execution of fib.wat::fib(1000)
-  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+  let (snark, instance) = WasmSNARK::<E, S1, S2>::prove(&pp, &wasm_ctx, step_size)?;
 
   // Verify the proof
   snark.verify(&pp, &instance)?;

--- a/examples/v1/kth_factor.rs
+++ b/examples/v1/kth_factor.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
 use zk_engine::{
-  nova::provider::Bn256EngineIPA,
+  nova::{
+    provider::{ipa_pc, Bn256EngineIPA},
+    spartan,
+    traits::Dual,
+  },
   utils::logging::init_logger,
   v1::{
     error::ZKWASMError,
@@ -11,6 +15,10 @@ use zk_engine::{
 
 // Curve Cycle to prove/verify on
 pub type E = Bn256EngineIPA;
+pub type EE1 = ipa_pc::EvaluationEngine<E>;
+pub type EE2 = ipa_pc::EvaluationEngine<Dual<E>>;
+pub type S1 = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE1>;
+pub type S2 = spartan::batched::BatchedRelaxedR1CSSNARK<Dual<E>, EE2>;
 
 fn main() -> Result<(), ZKWASMError> {
   init_logger();
@@ -22,7 +30,7 @@ fn main() -> Result<(), ZKWASMError> {
   let step_size = StepSize::new(1000).set_memory_step_size(50_000);
 
   // Produce setup material
-  let pp = WasmSNARK::<E>::setup(step_size);
+  let pp = WasmSNARK::<E, S1, S2>::setup(step_size);
 
   let wasm_args = WASMArgsBuilder::default()
     .file_path(PathBuf::from("wasm/nebula/kth_factor.wat"))?
@@ -31,7 +39,7 @@ fn main() -> Result<(), ZKWASMError> {
     .build();
   let wasm_ctx = WASMCtx::new(wasm_args);
 
-  let (snark, instance) = WasmSNARK::<E>::prove(&pp, &wasm_ctx, step_size)?;
+  let (snark, instance) = WasmSNARK::<E, S1, S2>::prove(&pp, &wasm_ctx, step_size)?;
 
   // Verify the proof
   snark.verify(&pp, &instance)?;

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -62,7 +62,7 @@ where
           _s2: PhantomData,
         })
       }
-      WasmSNARK::Compressed(_) => Err(ZKWASMError::AlreadyCompressed),
+      WasmSNARK::Compressed(_) => Err(ZKWASMError::NotRecursive),
     }
   }
 
@@ -82,7 +82,7 @@ where
         WasmSNARK::Recursive(wasm_snark) => {
           self.rs.prove_step(pp, wasm_snark, U)?;
         }
-        WasmSNARK::Compressed(_) => return Err(ZKWASMError::AlreadyCompressed),
+        WasmSNARK::Compressed(_) => return Err(ZKWASMError::NotRecursive),
       }
     }
 

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use itertools::Itertools;
 use nova::{
-  nebula::l2::{AggregationPublicParams, AggregationRecursiveSNARK},
+  nebula::layer_2::aggregation::{AggregationPublicParams, AggregationRecursiveSNARK},
   traits::CurveCycleEquipped,
 };
 use serde::{Deserialize, Serialize};

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -1,5 +1,5 @@
 //! This module implements aggregation logic for the zkWASM.
-use std::marker::PhantomData;
+use std::{cell::OnceCell, marker::PhantomData};
 
 use super::{
   error::ZKWASMError,
@@ -7,7 +7,10 @@ use super::{
 };
 use itertools::Itertools;
 use nova::{
-  nebula::layer_2::aggregation::{AggregationPublicParams, AggregationRecursiveSNARK},
+  nebula::layer_2::aggregation::{
+    compression::{CompressedSNARK, ProverKey, VerifierKey},
+    AggregationPublicParams as NovaAggregationPublicParams, AggregationRecursiveSNARK,
+  },
   traits::{snark::BatchedRelaxedR1CSSNARKTrait, CurveCycleEquipped, Dual},
 };
 use serde::{Deserialize, Serialize};
@@ -15,16 +18,47 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 mod tests;
 
-/// Get aggregation public parameters
-pub fn gen_aggregation_pp<E, S1, S2>(
-  wasm_pp: WASMPublicParams<E, S1, S2>,
-) -> AggregationPublicParams<E>
+/// Aggregation public parameters
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct AggregationPublicParams<E, S1, S2>
 where
   E: CurveCycleEquipped,
   S1: BatchedRelaxedR1CSSNARKTrait<E>,
   S2: BatchedRelaxedR1CSSNARKTrait<Dual<E>>,
 {
-  AggregationPublicParams::setup(wasm_pp)
+  pp: NovaAggregationPublicParams<E>,
+  /// Prover and verifier key for final proof compression
+  #[serde(skip)]
+  pk_and_vk: OnceCell<(ProverKey<E, S1, S2>, VerifierKey<E, S1, S2>)>,
+}
+
+impl<E, S1, S2> AggregationPublicParams<E, S1, S2>
+where
+  E: CurveCycleEquipped,
+  S1: BatchedRelaxedR1CSSNARKTrait<E>,
+  S2: BatchedRelaxedR1CSSNARKTrait<Dual<E>>,
+{
+  /// provides a reference to a ProverKey suitable for producing a CompressedProof
+  pub fn pk(&self) -> &ProverKey<E, S1, S2> {
+    let (pk, _vk) = self
+      .pk_and_vk
+      .get_or_init(|| CompressedSNARK::<E, S1, S2>::setup(&self.pp).unwrap());
+    pk
+  }
+
+  /// provides a reference to a VerifierKey suitable for verifying a CompressedProof
+  pub fn vk(&self) -> &VerifierKey<E, S1, S2> {
+    let (_pk, vk) = self
+      .pk_and_vk
+      .get_or_init(|| CompressedSNARK::<E, S1, S2>::setup(&self.pp).unwrap());
+    vk
+  }
+
+  /// Get the inner public parameters
+  pub fn inner(&self) -> &NovaAggregationPublicParams<E> {
+    &self.pp
+  }
 }
 
 /// Aggregation SNARK used to aggregate [`WasmSNARK`]'s
@@ -47,15 +81,23 @@ where
   S1: BatchedRelaxedR1CSSNARKTrait<E>,
   S2: BatchedRelaxedR1CSSNARKTrait<Dual<E>>,
 {
+  /// Get the [`AggregationPublicParams`]
+  pub fn setup(wasm_pp: WASMPublicParams<E, S1, S2>) -> AggregationPublicParams<E, S1, S2> {
+    let pp = NovaAggregationPublicParams::<E>::setup(wasm_pp);
+    AggregationPublicParams {
+      pp,
+      pk_and_vk: OnceCell::new(),
+    }
+  }
   /// Create a new instance of [`AggregationSNARK`]
   pub fn new(
-    pp: &AggregationPublicParams<E>,
+    pp: &AggregationPublicParams<E, S1, S2>,
     wasm_snark: &WasmSNARK<E, S1, S2>,
     U: &ZKWASMInstance<E>,
   ) -> Result<Self, ZKWASMError> {
     match wasm_snark {
       WasmSNARK::Recursive(wasm_snark) => {
-        let rs = AggregationRecursiveSNARK::new(pp, wasm_snark, U)?;
+        let rs = AggregationRecursiveSNARK::new(pp.inner(), wasm_snark, U)?;
         Ok(Self {
           rs,
           _s1: PhantomData,
@@ -73,14 +115,14 @@ where
   /// Panics if the number of [`WasmSNARK`]'s and U's ([`ZKWASMInstance`]'s) are not equal
   pub fn aggregate(
     &mut self,
-    pp: &AggregationPublicParams<E>,
+    pp: &AggregationPublicParams<E, S1, S2>,
     wasm_snarks: &[WasmSNARK<E, S1, S2>],
     U: &[ZKWASMInstance<E>],
   ) -> Result<(), ZKWASMError> {
     for (snark, U) in wasm_snarks.iter().zip_eq(U.iter()) {
       match snark {
         WasmSNARK::Recursive(wasm_snark) => {
-          self.rs.prove_step(pp, wasm_snark, U)?;
+          self.rs.prove_step(pp.inner(), wasm_snark, U)?;
         }
         WasmSNARK::Compressed(_) => return Err(ZKWASMError::NotRecursive),
       }
@@ -90,8 +132,17 @@ where
   }
 
   /// Verify the [`AggregationSNARK`]
-  pub fn verify(&self, pp: &AggregationPublicParams<E>) -> Result<(), ZKWASMError> {
-    self.rs.verify(pp)?;
+  pub fn verify(&self, pp: &AggregationPublicParams<E, S1, S2>) -> Result<(), ZKWASMError> {
+    self.rs.verify(pp.inner())?;
     Ok(())
+  }
+
+  /// Apply Spartan on top of the [`AggregationSNARK`]
+  pub fn compress(
+    &self,
+    pp: &AggregationPublicParams<E, S1, S2>,
+  ) -> Result<CompressedSNARK<E, S1, S2>, ZKWASMError> {
+    let snark = CompressedSNARK::prove(pp.inner(), pp.pk(), &self.rs)?;
+    Ok(snark)
   }
 }

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -101,7 +101,7 @@ where
   ) -> Result<Self, ZKWASMError> {
     match wasm_snark {
       WasmSNARK::Recursive(wasm_snark) => {
-        let rs = AggregationRecursiveSNARK::new(pp.inner(), wasm_snark, U)?;
+        let rs = AggregationRecursiveSNARK::new(pp.inner(), wasm_snark.as_ref(), U)?;
         Ok(Self {
           rs,
           _s1: PhantomData,
@@ -126,7 +126,7 @@ where
     for (snark, U) in wasm_snarks.iter().zip_eq(U.iter()) {
       match snark {
         WasmSNARK::Recursive(wasm_snark) => {
-          self.rs.prove_step(pp.inner(), wasm_snark, U)?;
+          self.rs.prove_step(pp.inner(), wasm_snark.as_ref(), U)?;
         }
         WasmSNARK::Compressed(_) => return Err(ZKWASMError::NotRecursive),
       }

--- a/src/v1/aggregation/mod.rs
+++ b/src/v1/aggregation/mod.rs
@@ -11,7 +11,10 @@ use nova::{
     compression::{CompressedSNARK, ProverKey, VerifierKey},
     AggregationPublicParams as NovaAggregationPublicParams, AggregationRecursiveSNARK,
   },
-  traits::{snark::BatchedRelaxedR1CSSNARKTrait, CurveCycleEquipped, Dual},
+  traits::{
+    snark::{default_ck_hint, BatchedRelaxedR1CSSNARKTrait},
+    CurveCycleEquipped, Dual,
+  },
 };
 use serde::{Deserialize, Serialize};
 
@@ -83,7 +86,8 @@ where
 {
   /// Get the [`AggregationPublicParams`]
   pub fn setup(wasm_pp: WASMPublicParams<E, S1, S2>) -> AggregationPublicParams<E, S1, S2> {
-    let pp = NovaAggregationPublicParams::<E>::setup(wasm_pp);
+    let pp =
+      NovaAggregationPublicParams::<E>::setup(wasm_pp, &*default_ck_hint(), &*default_ck_hint());
     AggregationPublicParams {
       pp,
       pk_and_vk: OnceCell::new(),

--- a/src/v1/error.rs
+++ b/src/v1/error.rs
@@ -24,7 +24,7 @@ pub enum ZKWASMError {
   /// Something went wrong when verifying the multisets
   #[error("MultisetVerificationError")]
   MultisetVerificationError,
-  #[error("NotRecursive")]
+  #[error("Input SNARK needs to be Recursive")]
   /// Returned when trying to compress or aggregate an already compressed proof
   NotRecursive,
 }

--- a/src/v1/error.rs
+++ b/src/v1/error.rs
@@ -25,7 +25,7 @@ pub enum ZKWASMError {
   #[error("MultisetVerificationError")]
   MultisetVerificationError,
   #[error("AlreadyCompressed")]
-  /// Trying to compress and already compressedSNARK
+  /// Returned when trying to compress or aggregate an already compressed proof
   AlreadyCompressed,
 }
 

--- a/src/v1/error.rs
+++ b/src/v1/error.rs
@@ -19,7 +19,7 @@ pub enum ZKWASMError {
   #[error("WasmiError")]
   WasmiError(wasmi::Error),
   /// Failed to load WASM module
-  #[error("WasmError")]
+  #[error("WasmError: {0}")]
   WASMError(String),
   /// Something went wrong when verifying the multisets
   #[error("MultisetVerificationError")]

--- a/src/v1/error.rs
+++ b/src/v1/error.rs
@@ -24,9 +24,9 @@ pub enum ZKWASMError {
   /// Something went wrong when verifying the multisets
   #[error("MultisetVerificationError")]
   MultisetVerificationError,
-  #[error("AlreadyCompressed")]
+  #[error("NotRecursive")]
   /// Returned when trying to compress or aggregate an already compressed proof
-  AlreadyCompressed,
+  NotRecursive,
 }
 
 impl From<wasmi::Error> for ZKWASMError {

--- a/src/v1/error.rs
+++ b/src/v1/error.rs
@@ -24,6 +24,9 @@ pub enum ZKWASMError {
   /// Something went wrong when verifying the multisets
   #[error("MultisetVerificationError")]
   MultisetVerificationError,
+  #[error("AlreadyCompressed")]
+  /// Trying to compress and already compressedSNARK
+  AlreadyCompressed,
 }
 
 impl From<wasmi::Error> for ZKWASMError {

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::type_complexity)]
 pub mod aggregation;
 pub mod error;
-// pub mod sharding;
+pub mod sharding;
 pub mod utils;
 pub mod wasm_ctx;
 pub mod wasm_snark;

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -1,8 +1,8 @@
 //! V1 of zkEngine: Implements the Nebula paper for WASM ISA
 #![allow(clippy::type_complexity)]
-// pub mod aggregation;
-// pub mod sharding;
+pub mod aggregation;
 pub mod error;
+pub mod sharding;
 pub mod utils;
 pub mod wasm_ctx;
 pub mod wasm_snark;

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -1,8 +1,8 @@
 //! V1 of zkEngine: Implements the Nebula paper for WASM ISA
 #![allow(clippy::type_complexity)]
-pub mod aggregation;
 pub mod error;
-pub mod sharding;
+// pub mod aggregation;
+// pub mod sharding;
 pub mod utils;
 pub mod wasm_ctx;
 pub mod wasm_snark;

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -1,7 +1,7 @@
 //! V1 of zkEngine: Implements the Nebula paper for WASM ISA
 #![allow(clippy::type_complexity)]
+pub mod aggregation;
 pub mod error;
-// pub mod aggregation;
 // pub mod sharding;
 pub mod utils;
 pub mod wasm_ctx;

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -1,10 +1,11 @@
 //! V1 of zkEngine: Implements the Nebula paper for WASM ISA
 #![allow(clippy::type_complexity)]
-pub mod aggregation;
+// pub mod aggregation;
+// pub mod sharding;
 pub mod error;
-pub mod sharding;
-#[cfg(test)]
-mod tests;
 pub mod utils;
 pub mod wasm_ctx;
 pub mod wasm_snark;
+
+#[cfg(test)]
+mod tests;

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use itertools::Itertools;
 use nova::{
-  nebula::l2::sharding::{ShardingPublicParams, ShardingRecursiveSNARK},
+  nebula::layer_2::sharding::{ShardingPublicParams, ShardingRecursiveSNARK},
   traits::CurveCycleEquipped,
 };
 use serde::{Deserialize, Serialize};

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -14,7 +14,10 @@ use nova::{
     compression::{CompressedSNARK, ProverKey, VerifierKey},
     ShardingPublicParams as NovaShardingPublicParams, ShardingRecursiveSNARK,
   },
-  traits::{snark::BatchedRelaxedR1CSSNARKTrait, CurveCycleEquipped, Dual},
+  traits::{
+    snark::{default_ck_hint, BatchedRelaxedR1CSSNARKTrait},
+    CurveCycleEquipped, Dual,
+  },
 };
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
@@ -85,7 +88,8 @@ where
 {
   /// Get the [`ShardingPublicParams`]
   pub fn setup(wasm_pp: WASMPublicParams<E, S1, S2>) -> ShardingPublicParams<E, S1, S2> {
-    let pp = NovaShardingPublicParams::<E>::setup(wasm_pp);
+    let pp =
+      NovaShardingPublicParams::<E>::setup(wasm_pp, &*default_ck_hint(), &*default_ck_hint());
     ShardingPublicParams {
       pp,
       pk_and_vk: OnceCell::new(),

--- a/src/v1/sharding/mod.rs
+++ b/src/v1/sharding/mod.rs
@@ -108,7 +108,7 @@ where
   ) -> Result<Self, ZKWASMError> {
     match wasm_snark {
       WasmSNARK::Recursive(wasm_snark) => {
-        let rs = ShardingRecursiveSNARK::new(pp.inner(), wasm_snark, U)?;
+        let rs = ShardingRecursiveSNARK::new(pp.inner(), wasm_snark.as_ref(), U)?;
         Ok(Self {
           rs,
           _s1: PhantomData,
@@ -137,7 +137,7 @@ where
     for (snark, U) in wasm_snarks.iter().zip_eq(U.iter()) {
       match snark {
         WasmSNARK::Recursive(wasm_snark) => {
-          self.rs.prove_step(pp.inner(), wasm_snark, U)?;
+          self.rs.prove_step(pp.inner(), wasm_snark.as_ref(), U)?;
         }
         WasmSNARK::Compressed(_) => return Err(ZKWASMError::NotRecursive),
       }

--- a/src/v1/sharding/tests.rs
+++ b/src/v1/sharding/tests.rs
@@ -10,11 +10,19 @@ use crate::{
     wasm_snark::{StepSize, WASMPublicParams, WasmSNARK, ZKWASMInstance},
   },
 };
-use nova::provider::Bn256EngineIPA;
+use nova::{
+  provider::{ipa_pc, Bn256EngineIPA},
+  spartan,
+  traits::Dual,
+};
 use std::{path::PathBuf, time::Instant};
 
 /// Curve Cycle to prove/verify on
 pub type E = Bn256EngineIPA;
+pub type EE1 = ipa_pc::EvaluationEngine<E>;
+pub type EE2 = ipa_pc::EvaluationEngine<Dual<E>>;
+pub type S1 = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE1>;
+pub type S2 = spartan::batched::BatchedRelaxedR1CSSNARK<Dual<E>, EE2>;
 
 #[test]
 fn test_sharding_eq_func_mismatch() {
@@ -117,7 +125,7 @@ fn sim_nodes_and_orchestrator_node(
   // Public parameters used by [`WasmSNARK`]
   //
   // All nodes will use the same public parameters
-  let node_pp = WasmSNARK::<E>::setup(step_size);
+  let node_pp = WasmSNARK::<E, S1, S2>::setup(step_size);
 
   // calculate number of shards from number of opcodes and shard opcode size
   let num_shards = num_shards(
@@ -177,12 +185,12 @@ fn num_shards(program: &impl ZKWASMCtx, shard_opcode_size: usize) -> usize {
 }
 
 fn node_nw(
-  node_pp: &WASMPublicParams<E>,
+  node_pp: &WASMPublicParams<E, S1, S2>,
   wasm_args_builder: &WASMArgsBuilder,
   num_shards: usize,
   step_size: StepSize,
   shard_opcode_size: usize,
-) -> (Vec<WasmSNARK<E>>, Vec<ZKWASMInstance<E>>) {
+) -> (Vec<WasmSNARK<E, S1, S2>>, Vec<ZKWASMInstance<E>>) {
   let mut start = 0;
   let mut end = shard_opcode_size;
   let mut node_snarks = Vec::new();
@@ -195,7 +203,7 @@ fn node_nw(
         .trace_slice(TraceSliceValues::new(start, end))
         .build(),
     );
-    let (snark, U) = WasmSNARK::<E>::prove(node_pp, &wasm_ctx, step_size).unwrap();
+    let (snark, U) = WasmSNARK::<E, S1, S2>::prove(node_pp, &wasm_ctx, step_size).unwrap();
     snark.verify(node_pp, &U).unwrap();
     node_snarks.push(snark);
     node_instances.push(U);

--- a/src/v1/sharding/tests.rs
+++ b/src/v1/sharding/tests.rs
@@ -1,4 +1,4 @@
-use super::{gen_sharding_pp, ShardingSNARK};
+use super::ShardingSNARK;
 use crate::{
   utils::logging::init_logger,
   v1::{
@@ -148,7 +148,7 @@ fn sim_nodes_and_orchestrator_node(
   // Generate sharding public parameters
   //
   // This is the public parameters used by the orchestrator node
-  let sharding_pp = gen_sharding_pp(node_pp);
+  let sharding_pp = ShardingSNARK::setup(node_pp);
 
   // Create a new instance of ShardingSNARK with the first node SNARK and instance
   //
@@ -170,6 +170,11 @@ fn sim_nodes_and_orchestrator_node(
 
   // Verify sharding was done correctly
   sharding_snark.verify(&sharding_pp).unwrap();
+
+  let compressed_snark = sharding_snark.compress(&sharding_pp).unwrap();
+  compressed_snark
+    .verify(sharding_pp.inner(), sharding_pp.vk())
+    .unwrap();
 }
 
 fn num_shards(program: &impl ZKWASMCtx, shard_opcode_size: usize) -> usize {

--- a/src/v1/sharding/tests.rs
+++ b/src/v1/sharding/tests.rs
@@ -187,7 +187,6 @@ fn node_nw(
   let mut end = shard_opcode_size;
   let mut node_snarks = Vec::new();
   let mut node_instances = Vec::new();
-
   for i in 0..num_shards {
     let shard_proving_timer = start_timer!(format!("Proving Shard {}/{}", i + 1, num_shards));
     let wasm_ctx = WasiWASMCtx::new(
@@ -196,13 +195,10 @@ fn node_nw(
         .trace_slice(TraceSliceValues::new(start, end))
         .build(),
     );
-
     let (snark, U) = WasmSNARK::<E>::prove(node_pp, &wasm_ctx, step_size).unwrap();
     snark.verify(node_pp, &U).unwrap();
-
     node_snarks.push(snark);
     node_instances.push(U);
-
     start = end;
     end += shard_opcode_size;
     stop_timer!(shard_proving_timer);

--- a/src/v1/tests.rs
+++ b/src/v1/tests.rs
@@ -26,8 +26,16 @@ fn test_wasm_snark_with(wasm_ctx: impl ZKWASMCtx, step_size: StepSize) -> Result
   let pp = WasmSNARK::<E, S1, S2>::setup(step_size);
   stop_timer!(pp_timer);
 
-  let proving_timer = start_timer!("Producing WasmSNARK");
-  let (snark, U) = WasmSNARK::<E, S1, S2>::prove(&pp, &wasm_ctx, step_size)?;
+  let proving_timer = start_timer!("Producing RecursiveWasmSNARK");
+  let (rs_snark, U) = WasmSNARK::<E, S1, S2>::prove(&pp, &wasm_ctx, step_size)?;
+  stop_timer!(proving_timer);
+
+  let verification_timer = start_timer!("Verifying RecursiveWasmSNARK");
+  rs_snark.verify(&pp, &U).unwrap();
+  stop_timer!(verification_timer);
+
+  let proving_timer = start_timer!("Producing compressedSNARK");
+  let snark = rs_snark.compress(&pp)?;
   stop_timer!(proving_timer);
 
   let verification_timer = start_timer!("Verifying WasmSNARK");

--- a/src/v1/tests.rs
+++ b/src/v1/tests.rs
@@ -35,7 +35,7 @@ fn test_wasm_snark_with(wasm_ctx: impl ZKWASMCtx, step_size: StepSize) -> Result
   stop_timer!(verification_timer);
 
   let proving_timer = start_timer!("Producing compressedSNARK");
-  let snark = rs_snark.compress(&pp)?;
+  let snark = rs_snark.compress(&pp, &U)?;
   stop_timer!(proving_timer);
 
   let verification_timer = start_timer!("Verifying WasmSNARK");

--- a/src/v1/wasm_snark/mcc/mod.rs
+++ b/src/v1/wasm_snark/mcc/mod.rs
@@ -11,7 +11,7 @@ use super::{
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use ff::PrimeField;
 use itertools::Itertools;
-use nova::nebula::rs::StepCircuit;
+use nova::nebula::{audit_rs::AuditStepCircuit, rs::StepCircuit};
 
 pub mod multiset_ops;
 #[cfg(test)]
@@ -149,7 +149,7 @@ pub struct ScanCircuit {
   FS: Vec<(usize, u64, u64)>, // Vec<(a, v, t)>
 }
 
-impl<F> StepCircuit<F> for ScanCircuit
+impl<F> AuditStepCircuit<F> for ScanCircuit
 where
   F: PrimeField,
 {
@@ -228,16 +228,19 @@ where
     Ok(vec![gamma, alpha, h_is, h_fs])
   }
 
-  fn non_deterministic_advice(&self) -> Vec<F> {
+  fn IS_advice(&self) -> Vec<F> {
     self
       .IS
       .iter()
-      .zip_eq(self.FS.iter())
-      .flat_map(|(is, fs)| {
-        avt_tuple_to_scalar_vec::<F>(*is)
-          .into_iter()
-          .chain(avt_tuple_to_scalar_vec::<F>(*fs))
-      })
+      .flat_map(|is| avt_tuple_to_scalar_vec::<F>(*is))
+      .collect()
+  }
+
+  fn FS_advice(&self) -> Vec<F> {
+    self
+      .FS
+      .iter()
+      .flat_map(|fs| avt_tuple_to_scalar_vec::<F>(*fs))
       .collect()
   }
 }

--- a/src/v1/wasm_snark/mod.rs
+++ b/src/v1/wasm_snark/mod.rs
@@ -122,7 +122,7 @@ where
   /// RecursiveSNARK for WASM execution
   Recursive(Box<RecursiveWasmSNARK<E>>),
   /// CompressedSNARK for WASM execution
-  Compressed(CompressedSNARK<E, S1, S2>),
+  Compressed(Box<CompressedSNARK<E, S1, S2>>),
 }
 
 impl<E, S1, S2> WasmSNARK<E, S1, S2>
@@ -432,12 +432,12 @@ where
     U: &ZKWASMInstance<E>,
   ) -> Result<Self, ZKWASMError> {
     match self {
-      Self::Recursive(rs) => Ok(Self::Compressed(CompressedSNARK::prove(
+      Self::Recursive(rs) => Ok(Self::Compressed(Box::new(CompressedSNARK::prove(
         pp,
         pp.pk(),
         rs.as_ref(),
         U.into(),
-      )?)),
+      )?))),
       Self::Compressed(..) => Err(ZKWASMError::NotRecursive),
     }
   }

--- a/src/v1/wasm_snark/mod.rs
+++ b/src/v1/wasm_snark/mod.rs
@@ -440,16 +440,12 @@ pub fn construct_IS(
     0
   };
 
-  tracing::debug!("shard size: {shard_size}, sharding pad len: {sharding_pad_len}");
-
   IS_execution_trace.iter().enumerate().for_each(|(i, vm)| {
     if i != 0 && i % shard_size == 0 {
-      tracing::debug!("adding {sharding_pad_len} padding at step i: {i}");
       IS_padding(sharding_pad_len, IS, global_ts, IS_sizes);
     }
     let _ = step_RS_WS(vm, IS, global_ts, IS_sizes);
   });
-
   if !IS_execution_trace.is_empty() && is_sharded {
     IS_padding(sharding_pad_len, IS, global_ts, IS_sizes);
   }

--- a/src/v1/wasm_snark/mod.rs
+++ b/src/v1/wasm_snark/mod.rs
@@ -430,7 +430,7 @@ where
   pub fn compress(&self, pp: &WASMPublicParams<E, S1, S2>) -> Result<Self, ZKWASMError> {
     match self {
       Self::Recursive(rs) => Ok(Self::Compressed(CompressedSNARK::prove(pp, pp.pk(), rs)?)),
-      Self::Compressed(..) => Err(ZKWASMError::AlreadyCompressed),
+      Self::Compressed(..) => Err(ZKWASMError::NotRecursive),
     }
   }
 


### PR DESCRIPTION
This PR introduces the ability to compress the recursive SNARKs outputted by zkEngine using Spartan -> the zkEngine API now supports compression for the three main types of recursive SNARKs:

1. **`WasmSNARK`**: A general purpose recursive SNARK, typically produced when a client uses a WASM program and runs it through zkVM to generate a proof without any sharding or aggregation.
2. `AggregationSNARK`: Produced by aggregating multiple `WasmSNARK`s.
3. `ShardingSNARK`: Produced by sharding multiple `WasmSNARK`s.

These three types —`WasmSNARK`, `AggregationSNARK`, and `ShardingSNARK` — can now be compressed with Spartan, reducing the size of the recursive SNARK's outputted originally by zkEngine.

# Note

To accommodate this compression-step, the API for the recursive SNARK's have been updated to accept two additional type parameters, `S1` and `S2` which specify the Spartan type to use for compression. The following types are recommended for optimal performance:

```rust
use zk_engine::nova::{
    provider::{ipa_pc, Bn256EngineIPA},
    spartan,
    traits::Dual,
  };
  
// Curve-cycle to prove on
pub type E = Bn256EngineIPA;
// Primary PCS
pub type EE1 = ipa_pc::EvaluationEngine<E>;
// Secondary PCS
pub type EE2 = ipa_pc::EvaluationEngine<Dual<E>>;
// Primary Spartan type
pub type S1 = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE1>;
// Secondary Spartan type
pub type S2 = spartan::batched::BatchedRelaxedR1CSSNARK<Dual<E>, EE2>;
```

Example usage:

```rust
let pp = WasmSNARK::<E, S1, S2>::setup(step_size);
```

This PR also resolves #6 
i.e. you cannot swap inner execution and inner mcc proofs from 2 different `WasmSNARK` as `verify()` will fail due to certain checks.
___
P.S. I did a small refactor in `wasm_snark/mod.rs`
