### PR TITLE
Fix/constrain multiset sizes

### DIFF
--- a/src/wasm_snark/gadgets/int.rs
+++ b/src/wasm_snark/gadgets/int.rs
@@ -1,5 +1,5 @@
 use bellpepper::gadgets::Assignment;
-use bellpepper_core::{boolean::Boolean, num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use ff::PrimeField;
 
 use crate::wasm_snark::gadgets::num::Num;
@@ -12,7 +12,6 @@ pub fn add<F: PrimeField, CS: ConstraintSystem<F>>(
   let res = AllocatedNum::alloc(cs.namespace(|| "add_num"), || {
     let mut tmp = a.get_value().ok_or(SynthesisError::AssignmentMissing)?;
     tmp.add_assign(&b.get_value().ok_or(SynthesisError::AssignmentMissing)?);
-
     Ok(tmp)
   })?;
 
@@ -150,21 +149,6 @@ pub fn enforce_equal<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     |lc| lc + CS::one(),
     |lc| lc + b.get_variable(),
   );
-}
-
-/// alloc a field as a constant
-pub fn alloc_const<F: PrimeField, CS: ConstraintSystem<F>>(mut cs: CS, val: F) -> AllocatedNum<F> {
-  let allocated = AllocatedNum::<F>::alloc_infallible(cs.namespace(|| "allocate const"), || val);
-
-  // allocated * 1 = val
-  cs.enforce(
-    || "enforce constant",
-    |lc| lc + allocated.get_variable(),
-    |lc| lc + CS::one(),
-    |_| Boolean::Constant(true).lc(CS::one(), val),
-  );
-
-  allocated
 }
 
 /// Check if a < b

--- a/src/wasm_snark/gadgets/mod.rs
+++ b/src/wasm_snark/gadgets/mod.rs
@@ -1,3 +1,4 @@
 pub mod int;
 pub mod mcc;
+mod num;
 pub mod utils;

--- a/src/wasm_snark/gadgets/num.rs
+++ b/src/wasm_snark/gadgets/num.rs
@@ -1,0 +1,123 @@
+use bellpepper::gadgets::Assignment;
+use bellpepper_core::{
+  num::AllocatedNum, ConstraintSystem, LinearCombination, SynthesisError, Variable,
+};
+use ff::PrimeField;
+
+pub struct Num<F>
+where
+  F: PrimeField,
+{
+  value: Option<F>,
+  lc: LinearCombination<F>,
+}
+
+impl<F> Num<F>
+where
+  F: PrimeField,
+{
+  pub fn alloc<CS, Func>(mut cs: CS, value: Func) -> Result<Self, SynthesisError>
+  where
+    CS: ConstraintSystem<F>,
+    Func: FnOnce() -> Result<F, SynthesisError>,
+  {
+    let mut new_value = None;
+    let new_var = cs.alloc(
+      || "num",
+      || {
+        let tmp = value()?;
+        new_value = Some(tmp);
+        Ok(tmp)
+      },
+    )?;
+    Ok(Self {
+      value: new_value,
+      lc: LinearCombination::zero() + new_var,
+    })
+  }
+
+  pub fn fits_in_bits<CS>(&self, mut cs: CS, n_bits: usize) -> Result<(), SynthesisError>
+  where
+    CS: ConstraintSystem<F>,
+  {
+    // Allocate all but the first bit
+    let bits: Vec<Variable> = (1..n_bits)
+      .map(|i| {
+        cs.alloc(
+          || format!("bit {i}"),
+          || {
+            if *self.value.get()?.get_bit(i).get()? {
+              Ok(F::ONE)
+            } else {
+              Ok(F::ZERO)
+            }
+          },
+        )
+      })
+      .collect::<Result<_, _>>()?;
+    for (i, v) in bits.iter().enumerate() {
+      cs.enforce(
+        || format!("{i} is bit"),
+        |lc| lc + *v,
+        |lc| lc + CS::one() - *v,
+        |lc| lc,
+      )
+    }
+    // Last bit
+    cs.enforce(
+      || "last bit",
+      |mut lc| {
+        let mut f = F::ONE;
+        lc = lc + &self.lc;
+        for v in bits.iter() {
+          f = f.double();
+          lc = lc - (f, *v);
+        }
+        lc
+      },
+      |mut lc| {
+        lc = lc + CS::one();
+        let mut f = F::ONE;
+        lc = lc - &self.lc;
+        for v in bits.iter() {
+          f = f.double();
+          lc = lc + (f, *v);
+        }
+        lc
+      },
+      |lc| lc,
+    );
+    Ok(())
+  }
+
+  pub fn as_allocated_num<CS: ConstraintSystem<F>>(
+    &self,
+    mut cs: CS,
+  ) -> Result<AllocatedNum<F>, SynthesisError> {
+    let new = AllocatedNum::alloc(cs.namespace(|| "alloc"), || Ok(*self.value.get()?))?;
+    cs.enforce(
+      || "eq",
+      |lc| lc,
+      |lc| lc,
+      |lc| lc + new.get_variable() - &self.lc,
+    );
+    Ok(new)
+  }
+}
+
+trait BitAccess {
+  fn get_bit(&self, i: usize) -> Option<bool>;
+}
+
+impl<Scalar: PrimeField> BitAccess for Scalar {
+  fn get_bit(&self, i: usize) -> Option<bool> {
+    if i as u32 >= Scalar::NUM_BITS {
+      return None;
+    }
+
+    let (byte_pos, bit_pos) = (i / 8, i % 8);
+    let byte = self.to_repr().as_ref()[byte_pos];
+    let bit = byte >> bit_pos & 1;
+    Some(bit == 1)
+  }
+}

--- a/src/wasm_snark/mcc/mod.rs
+++ b/src/wasm_snark/mcc/mod.rs
@@ -2,8 +2,8 @@ use super::{
   avt_tuple_to_scalar_vec,
   gadgets::{
     int::{add, enforce_equal, enforce_lt_32, mul},
-    mcc::{alloc_avt_tuple, randomized_hash_func},
-    utils::alloc_one,
+    mcc::{alloc_avt_tuple, countable_hash, randomized_hash_func},
+    utils::{alloc_one, alloc_zero},
   },
   MEMORY_OPS_PER_STEP,
 };
@@ -29,7 +29,7 @@ where
   F: PrimeField + PartialOrd,
 {
   fn arity(&self) -> usize {
-    5
+    6
   }
 
   fn synthesize<CS: ConstraintSystem<F>>(
@@ -37,25 +37,20 @@ where
     cs: &mut CS,
     z: &[AllocatedNum<F>],
   ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
-    let (gamma, alpha, mut gts, mut h_rs, mut h_ws) = {
+    let (gamma, alpha, mut gts, mut h_rs, mut h_ws, size) = {
       (
         z[0].clone(),
         z[1].clone(),
         z[2].clone(),
         z[3].clone(),
         z[4].clone(),
+        z[5].clone(),
       )
     };
     let one = alloc_one(cs.namespace(|| "one"));
-
-    // 1. assert |RS| = |WS|
-    let RS_len = AllocatedNum::alloc(cs.namespace(|| "RS.len()"), || {
-      Ok(F::from(self.RS.len() as u64))
-    })?;
-    let WS_len = AllocatedNum::alloc(cs.namespace(|| "WS.len()"), || {
-      Ok(F::from(self.WS.len() as u64))
-    })?;
-    enforce_equal(cs, || " assert |RS| = |WS|", &RS_len, &WS_len);
+    // Used to assert |RS| = |WS|
+    let mut RS_size_count = alloc_zero(cs.namespace(|| "RS_size_count"));
+    let mut WS_size_count = alloc_zero(cs.namespace(|| "WS_size_count"));
 
     // 2. for i in 0..|RS|
     for (i, (rs, ws)) in self.RS.iter().zip_eq(self.WS.iter()).enumerate() {
@@ -74,8 +69,6 @@ where
       // (e) assert wt = ts
       enforce_equal(cs, || format!("{i} assert wt = ts"), &w_ts, &gts);
 
-      // (f) h_RS ← h_RS · Hash(gamma, alpha, a, v, rt)
-      //
       // Get Hash(gamma, alpha, a, v, rt)
       let hash_rs = randomized_hash_func(
         cs.namespace(|| format!("{i}, Hash(gamma, alpha, a, v, rt)")),
@@ -85,6 +78,17 @@ where
         &gamma,
         &alpha,
       )?;
+
+      // Add to RS size count
+      let RS_counting_el =
+        countable_hash(cs.namespace(|| format!("RS_counting_el_{i}")), &hash_rs)?;
+      RS_size_count = add(
+        cs.namespace(|| format!("{i}, RS_size_count ← RS_size_count + RS_counting_el")),
+        &RS_size_count,
+        &RS_counting_el,
+      )?;
+
+      // (f) h_RS ← h_RS · Hash(gamma, alpha, a, v, rt)
       h_rs = mul(
         cs.namespace(|| format!("{i}, update h_rs")),
         &h_rs,
@@ -101,6 +105,15 @@ where
         &alpha,
       )?;
 
+      // Add to count for WS
+      let WS_counting_el =
+        countable_hash(cs.namespace(|| format!("WS_counting_el_{i}")), &hash_ws)?;
+      WS_size_count = add(
+        cs.namespace(|| format!("{i}, WS_size_count ← WS_size_count + WS_counting_el")),
+        &WS_size_count,
+        &WS_counting_el,
+      )?;
+
       h_ws = mul(
         cs.namespace(|| format!("{i}, update h_ws")),
         &h_ws,
@@ -108,7 +121,11 @@ where
       )?;
     }
 
-    Ok(vec![gamma, alpha, gts, h_rs, h_ws])
+    // assert |RS| = |WS|
+    enforce_equal(cs, || "assert |RS| = |WS|", &RS_size_count, &WS_size_count);
+    enforce_equal(cs, || "|RS| == size", &RS_size_count, &size);
+
+    Ok(vec![gamma, alpha, gts, h_rs, h_ws, size])
   }
 
   fn non_deterministic_advice(&self) -> Vec<F> {
@@ -154,7 +171,7 @@ where
   F: PrimeField,
 {
   fn arity(&self) -> usize {
-    4
+    5
   }
 
   fn synthesize<CS: ConstraintSystem<F>>(
@@ -162,17 +179,17 @@ where
     cs: &mut CS,
     z: &[AllocatedNum<F>],
   ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
-    let (gamma, alpha, mut h_is, mut h_fs) =
-      { (z[0].clone(), z[1].clone(), z[2].clone(), z[3].clone()) };
+    let (gamma, alpha, mut h_is, mut h_fs, size) = (
+      z[0].clone(),
+      z[1].clone(),
+      z[2].clone(),
+      z[3].clone(),
+      z[4].clone(),
+    );
 
-    // 1. assert |IS| = |FS|
-    let IS_len = AllocatedNum::alloc(cs.namespace(|| "IS.len()"), || {
-      Ok(F::from(self.IS.len() as u64))
-    })?;
-    let FS_len = AllocatedNum::alloc(cs.namespace(|| "FS.len()"), || {
-      Ok(F::from(self.FS.len() as u64))
-    })?;
-    enforce_equal(cs, || " assert |IS| = |FS|", &IS_len, &FS_len);
+    // used to assert |IS| = |FS|
+    let mut IS_size_count = alloc_zero(cs.namespace(|| "IS_size_count"));
+    let mut FS_size_count = alloc_zero(cs.namespace(|| "FS_size_count"));
 
     // 2. for i in 0..|IS|
     for (i, (is, fs)) in self.IS.iter().zip_eq(self.FS.iter()).enumerate() {
@@ -191,7 +208,7 @@ where
       );
 
       // (d) h_IS ← h_IS · Hash(gamma, alpha, a, v, it)
-
+      //
       // Get Hash(gamma, alpha, a, v, it)
       let hash_is = randomized_hash_func(
         cs.namespace(|| format!("{i}, Hash(gamma, alpha, a, v, it)")),
@@ -200,6 +217,15 @@ where
         &i_ts,
         &gamma,
         &alpha,
+      )?;
+
+      // Add to IS size count
+      let IS_counting_el =
+        countable_hash(cs.namespace(|| format!("IS_counting_el_{i}")), &hash_is)?;
+      IS_size_count = add(
+        cs.namespace(|| format!("{i}, IS_size_count ← IS_size_count + IS_counting_el")),
+        &IS_size_count,
+        &IS_counting_el,
       )?;
 
       h_is = mul(
@@ -217,6 +243,13 @@ where
         &gamma,
         &alpha,
       )?;
+      let FS_counting_el =
+        countable_hash(cs.namespace(|| format!("FS_counting_el_{i}")), &hash_fs)?;
+      FS_size_count = add(
+        cs.namespace(|| format!("{i}, FS_size_count ← FS_size_count + FS_counting_el")),
+        &FS_size_count,
+        &FS_counting_el,
+      )?;
 
       h_fs = mul(
         cs.namespace(|| format!("{i}, update h_fs")),
@@ -224,8 +257,11 @@ where
         &hash_fs,
       )?;
     }
+    // assert |IS| = |FS|
+    enforce_equal(cs, || "assert |IS| = |FS|", &IS_size_count, &FS_size_count);
+    enforce_equal(cs, || "|IS| == size", &IS_size_count, &size);
 
-    Ok(vec![gamma, alpha, h_is, h_fs])
+    Ok(vec![gamma, alpha, h_is, h_fs, size])
   }
 
   fn IS_advice(&self) -> Vec<F> {
@@ -274,7 +310,7 @@ where
   F: PrimeField + PartialOrd,
 {
   fn arity(&self) -> usize {
-    5
+    6
   }
 
   fn synthesize<CS: ConstraintSystem<F>>(

--- a/src/wasm_snark/mcc/tests.rs
+++ b/src/wasm_snark/mcc/tests.rs
@@ -102,7 +102,7 @@ where
 }
 
 #[test]
-fn test_integer_hash() {
+fn test_mcc_integer_hash() {
   let mut rng = StdRng::from_seed([1; 32]);
   let wasm_args = WASMArgsBuilder::default()
     .file_path(PathBuf::from("wasm/nebula/integer_hash.wasm"))
@@ -116,7 +116,7 @@ fn test_integer_hash() {
 }
 
 #[test]
-fn test_gradient_boosting() {
+fn test_mcc_gradient_boosting() {
   init_logger();
   let mut rng = StdRng::from_seed([1; 32]);
   let wasm_args = WASMArgsBuilder::default()

--- a/src/wasm_snark/mod.rs
+++ b/src/wasm_snark/mod.rs
@@ -365,6 +365,7 @@ where
       E::Scalar::from(IS_gts),
       E::Scalar::ONE,
       E::Scalar::ONE,
+      E::Scalar::from((MEMORY_OPS_PER_STEP / 2) as u64),
     ];
     let mut ops_IC_i = E::Scalar::ZERO;
     tracing::debug!("Proving MCC ops circuits");
@@ -387,7 +388,13 @@ where
      */
 
     // z0 <- [gamma, alpha, h_IS=1, h_FS=1]
-    let scan_z0 = vec![gamma, alpha, E::Scalar::ONE, E::Scalar::ONE];
+    let scan_z0 = vec![
+      gamma,
+      alpha,
+      E::Scalar::ONE,
+      E::Scalar::ONE,
+      E::Scalar::from(step_size.memory as u64),
+    ];
     let mut scan_rs = AuditRecursiveSNARK::new(
       scan_pp,
       scan_circuits.first().ok_or(ZKWASMError::NoCircuit)?,

--- a/src/wasm_snark/mod.rs
+++ b/src/wasm_snark/mod.rs
@@ -128,6 +128,7 @@ where
 impl<E, S1, S2> WasmSNARK<E, S1, S2>
 where
   E: CurveCycleEquipped,
+  <E as Engine>::Scalar: PartialOrd,
   S1: BatchedRelaxedR1CSSNARKTrait<E>,
   S2: RelaxedR1CSSNARKTrait<Dual<E>>,
 {


### PR DESCRIPTION
Previously, our constraint for `assert |RS| = |WS|`  was not implemented correctly. Now, the first step is to calculate the size of the multiset as follows: we hash each element in the multiset and make it "countable" by converting the hash into a one (multiplying the hash by its inverse). To check the sizes, we sum these counts for RS and WS and verify that they are equal and we check that they size equals a public input size var. This was also done to constrain `assert |IS| = |FS|`
Additionally, I added the lt check in the ops circuit.