### PR TITLE
Fix performance issue

### DIFF
--- a/src/wasm_ctx.rs
+++ b/src/wasm_ctx.rs
@@ -230,9 +230,10 @@ pub trait ZKWASMCtx {
     //
     // [`unwrap_rc_refcell`] is safe to use here since this parent function ensures that the [`Rc`]
     // is the sole owner of the execution trace.
-    let tracer = unwrap_rc_refcell(tracer);
+    let mut tracer = unwrap_rc_refcell(tracer);
 
     // Get the MCC values used to construct the initial memory state of the zkWASM.
+    tracer.truncate_unuesed_mem();
     let IS_stack_len = tracer.IS_stack_len();
     let IS_mem_len = tracer.IS_mem_len();
     let IS = tracer.IS();

--- a/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
+++ b/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
@@ -104,7 +104,7 @@ impl Tracer {
             .execution_trace
             .iter()
             .filter_map(|vm| match vm.instr {
-                Instruction::I32Load(_offset)
+                | Instruction::I32Load(_offset)
                 | Instruction::I64Load(_offset)
                 | Instruction::F32Load(_offset)
                 | Instruction::F64Load(_offset)
@@ -127,6 +127,19 @@ impl Tracer {
                 | Instruction::I64Store8(_offset)
                 | Instruction::I64Store16(_offset)
                 | Instruction::I64Store32(_offset) => Some(vm.I),
+
+                | Instruction::MemoryFill
+                | Instruction::MemoryCopy => {
+                    let size = vm.I;
+                    let offset = vm.X;
+                    Some(offset + size)
+                },
+                | Instruction::MemoryInit(data_segment_index)
+                | Instruction::DataDrop(data_segment_index) => {
+                    println!("memory.init or datadrop: {:?}, data_segment_index: {:?}", vm.I, data_segment_index);
+                    None
+                }
+
                 _ => None,
             })
             .max();

--- a/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
+++ b/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
@@ -104,7 +104,7 @@ impl Tracer {
             .execution_trace
             .iter()
             .filter_map(|vm| match vm.instr {
-                | Instruction::I32Load(_offset)
+                Instruction::I32Load(_offset)
                 | Instruction::I64Load(_offset)
                 | Instruction::F32Load(_offset)
                 | Instruction::F64Load(_offset)
@@ -128,16 +128,18 @@ impl Tracer {
                 | Instruction::I64Store16(_offset)
                 | Instruction::I64Store32(_offset) => Some(vm.I),
 
-                | Instruction::MemoryFill
-                | Instruction::MemoryCopy => {
+                Instruction::MemoryFill | Instruction::MemoryCopy => {
                     let size = vm.I;
                     let offset = vm.X;
                     Some(offset + size)
-                },
-                | Instruction::MemoryInit(data_segment_index)
+                }
+                Instruction::MemoryInit(data_segment_index)
                 | Instruction::DataDrop(data_segment_index) => {
                     println!("MemoryInit and DataDrop are not supported");
-                    println!("memory.init or datadrop: {:?}, data_segment_index: {:?}", vm.I, data_segment_index);
+                    println!(
+                        "memory.init or datadrop: {:?}, data_segment_index: {:?}",
+                        vm.I, data_segment_index
+                    );
                     unimplemented!();
                 }
                 _ => None,

--- a/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
+++ b/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
@@ -136,10 +136,10 @@ impl Tracer {
                 },
                 | Instruction::MemoryInit(data_segment_index)
                 | Instruction::DataDrop(data_segment_index) => {
+                    println!("MemoryInit and DataDrop are not supported");
                     println!("memory.init or datadrop: {:?}, data_segment_index: {:?}", vm.I, data_segment_index);
-                    None
+                    unimplemented!();
                 }
-
                 _ => None,
             })
             .max();


### PR DESCRIPTION
## Overview

In this PR, I address a severe performance issue discovered during a benchmark. The benchmarks comparing novanet’s Fibonacci example with other zkVMs showed that novanet was over more 200x slower. 

The root cause is that, even though the Fibonacci code does not use linear memory at all, the entire (memory 16) region was being included in the IS. 

This did not appear in `examples/fib.rs` because the [WAT](https://github.com/ICME-Lab/zkEngine_dev/blob/main/wasm/misc/fib.wat) does not declare `(memory 16)`.  However, a typical Rust compiler output initializes at least 1MiB of memory, which means any program automatically commits a large unused region. 

Meanwhile, Jolt and other zkVMs commit memory only up to the highest used address, leading to significantly better performance. 

This PR fixes the problem by preventing unnecessary memory commits, greatly improving proving performance.

## Benchmark Results

The benchmarks compares novanet’s fibonacci example with other zkVMs in this [repository](https://github.com/grandchildrice/zkvm-benchmarks/tree/novanet).


![6192509643402625025](https://github.com/user-attachments/assets/ffbad717-993e-4f13-8e5c-ea8e10c29978)


The following benchmark compares a handwritten fibonacci implementation with the one  compiled by Rust.

![6192509643402625145](https://github.com/user-attachments/assets/d1eed27c-13b9-4e37-b907-ed02d172bd56)

## The Root Cause

At this function, all address that initialized by `(memory 16)` are added to `self.IS_mem` regardless of whether it was used or not.

https://github.com/ICME-Lab/zkEngine_dev/blob/4ef4d758f459b9948cfb7660f4e90a27c4e9a4d7/third-party/wasmi/crates/wasmi/src/tracer/mod.rs#L101-L111

## What was Done

I added `truncate_unuesed_mem` method to `Trace` struct. To call it before get IS and its length, unused addressed are truncated by the function.

You can test the new feature by running this WAT that uses specified address of linear memory.

```wat
(module
    (memory $0 16)
    (func $store (export "store") (param $N i32) (result i64)
        ;; Store '10' to address $N
        (i64.store
            (local.get $N)
            (i64.const 10)
        )
        ;; Load the value from address $N and return it
        (i64.load
            (local.get $N)
        )
    )
)
```