### PR TITLE
Fix use-after-free when resuming after loading code

### DIFF
--- a/third-party/wasmi/crates/wasmi/src/engine/executor.rs
+++ b/third-party/wasmi/crates/wasmi/src/engine/executor.rs
@@ -2926,10 +2926,10 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 }
             }
 
-            let instruction = unsafe { &*self.ip.ptr };
+            let instruction = &{*self.ip.get(&self.code_map)};
 
             // Copy the instruction for post instruction execution tracing
-            let instruction_copy = instruction.clone();
+            let instruction_copy = instruction;
 
             // Get the pre status of the instruction execution
             let pre_status = self.execute_instruction_pre(&instruction);
@@ -3633,7 +3633,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     fn fetch_drop_keep(&self, offset: usize) -> DropKeep {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);
-        match addr.get() {
+        match addr.get(&self.code_map) {
             Instruction::Return(drop_keep) => *drop_keep,
             _ => unreachable!("expected Return instruction word at this point"),
         }
@@ -3652,7 +3652,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     fn fetch_table_idx(&self, offset: usize) -> TableIdx {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);
-        match addr.get() {
+        match addr.get(&self.code_map) {
             Instruction::TableGet(table_idx) => *table_idx,
             _ => unreachable!("expected TableGet instruction word at this point"),
         }


### PR DESCRIPTION
This is an inherited, unreported bug from the upstream wasmi 0.31 series. It was fixed incidentally by the major rewrite in [wasmi 0.32](https://github.com/wasmi-labs/wasmi/releases/tag/v0.32.0).

The bug:
1. Pausing a call stack saves a `*const Instruction` into the CodeMap's instr Vec.
2. Loading new code exceeds the Vec's capacity and thus moves it somewhere else.
3. Resuming that call stack uses the old `*const Instruction` after free, segfaulting or worse.

The fix: Store offsets into the Vec instead of raw pointers. I guess this is probably a tiny bit slower, but at least it doesn't segfault.

The usecase is [Starstream](https://github.com/PaimaStudios/Starstream/) where we want to pause/load/resume and where we get some benefits from harmonizing our "traditional" WASM executor and our "ZK" WASM executor.