### PR TITLE
fix: remove out of bound witnesses when truncating the memory

### DIFF
--- a/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
+++ b/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
@@ -146,13 +146,13 @@ impl Tracer {
             })
             .max();
 
-        self.execution_trace.retain(|vm| {
-            vm.instr != Instruction::HostCallStep || (vm.Y * 8) <= highest_address.unwrap_or(0)
-        });
-
         // Truncate to the largest 8-byte chunk that can accommodate the used highest address.
         let new_len = highest_address.map_or(0, |addr| (addr / 7) + 1);
+
         self.IS_mem.truncate(new_len as usize);
+
+        self.execution_trace
+            .retain(|vm| vm.instr != Instruction::HostCallStep || vm.Y < new_len);
     }
 
     /// Push initial heap/linear WASM memory to tracer for MCC

--- a/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
+++ b/third-party/wasmi/crates/wasmi/src/tracer/mod.rs
@@ -146,6 +146,10 @@ impl Tracer {
             })
             .max();
 
+        self.execution_trace.retain(|vm| {
+            vm.instr != Instruction::HostCallStep || (vm.Y * 8) <= highest_address.unwrap_or(0)
+        });
+
         // Truncate to the largest 8-byte chunk that can accommodate the used highest address.
         let new_len = highest_address.map_or(0, |addr| (addr / 7) + 1);
         self.IS_mem.truncate(new_len as usize);

--- a/wasm/host_call_test.wat
+++ b/wasm/host_call_test.wat
@@ -1,0 +1,10 @@
+ (module
+   (import "host" "call" (func $f (param i32) (result i32)))
+   (memory 1 2)
+   (func $test
+    (i32.const 42)
+    (call $f)
+    (drop)
+   )
+   (export "test" (func $test))
+ )


### PR DESCRIPTION
closes #47 

I can add a test if preferred, I'm just not sure where to put it.