### PR TITLE
Remove forced getrandom js feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,7 +2144,6 @@ dependencies = [
  "anyhow",
  "arecibo",
  "ff",
- "getrandom",
  "itertools 0.12.1",
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ tracing = { version = "0.1.40", features = ["log"] }
 thiserror = "1.0.61"
 tracing-texray = "0.2.0"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmi_wasi = { path = "./third-party/wasmi/crates/wasi" }
 


### PR DESCRIPTION
[getrandom's documentation][doc] says about the `js` Cargo feature:
> Library crates should generally not enable this feature, leaving such a decision to _users_ of their library.

The effect of this feature inclusion is that WebAssembly consumers of the `zk-engine` crate are forcibly locked in to using wasm-bindgen rather than supplying their own `getrandom` backend, which can be inconvenient.

This dependency block has been present since the initial commit 05529dc14d83f4285e36c7aeadaea5bac68a70ee.

See also https://github.com/wyattbenno777/arecibo/pull/28.

[doc]: https://docs.rs/getrandom/0.2.16/getrandom/index.html#webassembly-support